### PR TITLE
Add a tmp check for empty string in TypeManip::compound

### DIFF
--- a/src/TypeManip.cxx
+++ b/src/TypeManip.cxx
@@ -155,6 +155,9 @@ std::string CPyCppyy::TypeManip::template_base(const std::string& cppname)
 //----------------------------------------------------------------------------
 std::string CPyCppyy::TypeManip::compound(const std::string& name)
 {
+// FIXME: temporary fix for translation unit decl being passed in 
+// CreateExecutor from InitExecutor_ (run test10_object_identity), remove later
+    if (name.empty()) return "";
 // Break down the compound of a fully qualified type name.
     std::string cleanName = remove_const(name);
     auto idx = find_qualifier_index(cleanName);


### PR DESCRIPTION
Prevents it from trying to compute the underlying type if TU scope is passed