### PR TITLE
Forward declarations are incomplete entities and we should skip them.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,32 +212,15 @@ jobs:
         make all || true
         python -m pip install --upgrade pip
         python -m pip install pytest
-        export PASSED=0
-        export NO_OF_TESTS=0
-        export SETUP_PLAN=$(python -m pytest --setup-plan | grep -o -P '(?<=test\/).*?(?=\ \(fixtures)')
-        echo ::group::Test Status
-        set +e
-        for test in ${SETUP_PLAN} ; do
-          NO_OF_TESTS=$((NO_OF_TESTS+1))
-          (
-            python -m pytest -s $test >> test.log 2>&1
-          )
-          if [[ $? -eq 0 ]]; then
-            PASSED=$((PASSED+1))
-            echo "$test PASSED"
-          else
-            echo "$test FAILED"
-          fi
-        done
-        set -e
-        echo ::endgroup::
-        echo "TEST SUMMARY: $PASSED out of $NO_OF_TESTS tests passed"
+        python -m pip install pytest-xdist
+
         echo ::group::Test Logs
-        cat test.log
+        python -m pytest -n auto -sv --max-worker-restart 512 | tee test.log 2>&1
         echo ::endgroup::
-        if [[ $PASSED -ne $NO_OF_TESTS ]]; then
-          exit 1
-        fi
+
+        echo "TEST SUMMARY: \n"
+        tail -n1 test.log
+        echo "OF TOTAL $(python3 -m pytest  --collect-only -q | tail -n1)"
     - name: Setup tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3

--- a/src/CPPInstance.h
+++ b/src/CPPInstance.h
@@ -61,7 +61,7 @@ public:
 // access to C++ pointer and type
     void*  GetObject();
     void*& GetObjectRaw() { return IsExtended() ? *(void**) fObject : fObject; }
-    Cppyy::TCppType_t ObjectIsA(bool check_smart = true) const;
+    Cppyy::TCppScope_t ObjectIsA(bool check_smart = true) const;
 
 // memory management: ownership of the underlying C++ object
     void PythonOwns();
@@ -109,7 +109,7 @@ inline void* CPPInstance::GetObject()
 }
 
 //----------------------------------------------------------------------------
-inline Cppyy::TCppType_t CPPInstance::ObjectIsA(bool check_smart) const
+inline Cppyy::TCppScope_t CPPInstance::ObjectIsA(bool check_smart) const
 {
 // Retrieve the C++ type identifier (or raw type if smart).
     if (check_smart || !IsSmart()) return ((CPPClass*)Py_TYPE(this))->fCppType;

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -225,7 +225,7 @@ namespace CPyCppyy {
     PyObject* gIllException  = nullptr;
     PyObject* gAbrtException = nullptr;
     std::map<std::string, std::vector<PyObject*>> gPythonizations;
-    std::set<Cppyy::TCppType_t> gPinnedTypes;
+    std::set<Cppyy::TCppScope_t> gPinnedTypes;
     std::ostringstream gCapturedError;
     std::streambuf* gOldErrorBuffer = nullptr;
 }

--- a/src/Dispatcher.cxx
+++ b/src/Dispatcher.cxx
@@ -286,7 +286,7 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
                     Cppyy::TCppIndex_t nArgs = Cppyy::GetMethodNumArgs(method);
                     for (Cppyy::TCppIndex_t i = 0; i < nArgs; ++i) {
                         if (i != 0) code << ", ";
-                        code << Cppyy::GetMethodArgType(method, i) << " arg" << i;
+                        code << Cppyy::GetMethodArgTypeAsString(method, i) << " arg" << i;
                     }
                     code << ") ";
                     if (Cppyy::IsConstMethod(method)) code << "const ";

--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -94,18 +94,19 @@ CPPYY_IMPL_GILCALL(PY_LONG_DOUBLE, LD)
 CPPYY_IMPL_GILCALL(void*,          R)
 
 static inline Cppyy::TCppObject_t GILCallO(Cppyy::TCppMethod_t method,
-    Cppyy::TCppObject_t self, CPyCppyy::CallContext* ctxt, Cppyy::TCppType_t klass)
+    Cppyy::TCppObject_t self, CPyCppyy::CallContext* ctxt, Cppyy::TCppScope_t klass)
 {
+    Cppyy::TCppType_t klass_ty = Cppyy::GetTypeFromScope(klass);
 #ifdef PRINT_DEBUG
     printf("GILCallO: %p, %p\n", klass, Cppyy::GetType("double"));
 #endif
 #ifdef WITH_THREAD
     if (!ReleasesGIL(ctxt))
 #endif
-        return Cppyy::CallO(method, self, ctxt->GetEncodedSize(), ctxt->GetArgs(), klass);
+        return Cppyy::CallO(method, self, ctxt->GetEncodedSize(), ctxt->GetArgs(), klass_ty);
 #ifdef WITH_THREAD
     GILControl gc{};
-    return Cppyy::CallO(method, self, ctxt->GetEncodedSize(), ctxt->GetArgs(), klass);
+    return Cppyy::CallO(method, self, ctxt->GetEncodedSize(), ctxt->GetArgs(), klass_ty);
 #endif
 }
 

--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -419,7 +419,7 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass, cons
 }
 
 //----------------------------------------------------------------------------
-static void CollectUniqueBases(Cppyy::TCppType_t klass, std::deque<Cppyy::TCppScope_t>& uqb)
+static void CollectUniqueBases(Cppyy::TCppScope_t klass, std::deque<Cppyy::TCppScope_t>& uqb)
 {
 // collect bases in acceptable mro order, while removing duplicates (this may
 // break the overload resolution in esoteric cases, but otherwise the class can
@@ -427,7 +427,7 @@ static void CollectUniqueBases(Cppyy::TCppType_t klass, std::deque<Cppyy::TCppSc
     size_t nbases = Cppyy::GetNumBases(klass);
 
     for (size_t ibase = 0; ibase < nbases; ++ibase) {
-        Cppyy::TCppType_t tp = Cppyy::GetBaseScope(klass, ibase);
+        Cppyy::TCppScope_t tp = Cppyy::GetBaseScope(klass, ibase);
         int decision = 2;
         if (!tp) continue;   // means this base with not be available Python-side
         for (size_t ibase2 = 0; ibase2 < uqb.size(); ++ibase2) {


### PR DESCRIPTION
The work on the InterOp library has shown that we try to build proxy classes for entities which are only forward declared which leads to crashes. This patch tries to protect against these cases by saving some work and exiting early.

@wlav, can you take a look? This change is perhaps useful upstream.