### PR TITLE
Add fixes for the crash in test_datatypes.py::TestDATATYPES::test29_std_function_life_lines

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3189,6 +3189,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
     }
 
 // resolve typedefs etc.
+    Cppyy::TCppType_t resolvedType = Cppyy::ResolveType(type);
     const std::string& resolvedTypeStr = Cppyy::GetTypeAsString(resolvedType);
 
 // a full, qualified matching converter is preferred
@@ -3202,6 +3203,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
 //-- nothing? ok, collect information about the type and possible qualifiers/decorators
     bool isConst = strncmp(resolvedTypeStr.c_str(), "const", 5) == 0;
     const std::string& cpd = TypeManip::compound(resolvedTypeStr);
+    Cppyy::TCppType_t realType = Cppyy::GetRealType(type);
     std::string realTypeStr   = TypeManip::clean_type(resolvedTypeStr, false, true);
     std::string realUnresolvedTypeStr   = TypeManip::clean_type(fullType, false, true);
 
@@ -3272,7 +3274,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
         } else
             cnv = CreateConverter(value_type);
         if (cnv || use_byte_cnv)
-            return new InitializerListConverter(Cppyy::GetScope(realTypeStr),
+            return new InitializerListConverter(Cppyy::GetScopeFromType(realType),
                     CreateConverter(value_type), cnv, Cppyy::SizeOf(value_type));
     }
 
@@ -3285,7 +3287,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
 
     // get actual converter for normal passing
         Converter* cnv = selectInstanceCnv(
-            Cppyy::GetScope(realTypeStr), cpd, dims, isConst, control);
+            Cppyy::GetScopeFromType(realType), cpd, dims, isConst, control);
 
         if (cnv) {
         // get the type of the underlying (TODO: use target_type?)

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3297,8 +3297,9 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
                 auto sz1 = pos1-pos-14;
                 if (resolvedTypeStr[pos+14+sz1-1] == ' ') sz1 -= 1;
 
+                const std::string &argsStr = resolvedTypeStr.substr(pos1, pos2-pos1+1).c_str();
                 return new StdFunctionConverter(cnv,
-                    resolvedTypeStr.substr(pos+14, sz1), resolvedTypeStr.substr(pos1, pos2-pos1+1));
+                    resolvedTypeStr.substr(pos+14, sz1), argsStr == "(void)"? "()" : argsStr);
             } else if (cnv->HasState())
                 delete cnv;
         }


### PR DESCRIPTION
This doesn't fix the full test, just the crash, so now the test `xfail`s with an error message instead of seg faulting.