### PR TITLE
We can call this routine with empty string causing memory issues.

### DIFF
--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -794,13 +794,18 @@ CPyCppyy::Executor* CPyCppyy::CreateExecutor(const std::string& fullType, cdims_
 //
 // If all fails, void is used, which will cause the return type to be ignored on use
 
+  // FIXME:
+  //assert(!fullType.empty() && "This routine assumes non-empty fullType");
+  if (fullType.empty())
+    return nullptr;
+
 // an exactly matching executor is best
     ExecFactories_t::iterator h = gExecFactories.find(fullType);
     if (h != gExecFactories.end())
         return (h->second)(dims);
 
 // resolve typedefs etc.
-    const std::string& resolvedType = Cppyy::ResolveName(fullType);
+    const std::string resolvedType = Cppyy::ResolveName(fullType);
 
 // a full, qualified matching executor is preferred
     if (resolvedType != fullType) {


### PR DESCRIPTION
When called with an empty string (eg. the type was not found) we get the following valgrind report:

==2116907== Use of uninitialised value of size 8
==2116907==    at 0x48A3FE2: isalnum (ctype.c:26)
==2116907==    by 0x1B5E58A0: is_varchar(char) (TypeManip.cxx:14)
==2116907==    by 0x1B5E5934: find_qualifier_index(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (TypeManip.cxx:25)
==2116907==    by 0x1B5E605A: CPyCppyy::TypeManip::clean_type(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool) (TypeManip.cxx:110)