### PR TITLE
Fix bugs related to reflex, python side attribute lookup and template instantiation

### DIFF
--- a/include/CPyCppyy/API.h
+++ b/include/CPyCppyy/API.h
@@ -176,7 +176,8 @@ CPYCPPYY_EXTERN void* Instance_AsVoidPtr(PyObject* pyobject);
 // void* to C++ Instance (python object proxy) conversion, returns a new reference
 CPYCPPYY_EXTERN PyObject* Instance_FromVoidPtr(
     void* addr, const std::string& classname, bool python_owns = false);
-
+CPYCPPYY_EXTERN PyObject* Instance_FromVoidPtr(
+    void* addr, Cppyy::TCppScope_t klass_scope, bool python_owns = false);
 // type verifiers for C++ Scope
 CPYCPPYY_EXTERN bool Scope_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Scope_CheckExact(PyObject* pyobject);

--- a/src/API.cxx
+++ b/src/API.cxx
@@ -132,6 +132,23 @@ PyObject* CPyCppyy::Instance_FromVoidPtr(
     return pyobject;
 }
 
+//-----------------------------------------------------------------------------
+PyObject* CPyCppyy::Instance_FromVoidPtr(
+    void* addr, Cppyy::TCppScope_t klass_scope, bool python_owns)
+{
+// Bind the addr to a python object of class defined by classname.
+    if (!Initialize())
+        return nullptr;
+
+// perform cast (the call will check TClass and addr, and set python errors)
+    PyObject* pyobject = BindCppObjectNoCast(addr, klass_scope, false);
+
+// give ownership, for ref-counting, to the python side, if so requested
+    if (python_owns && CPPInstance_Check(pyobject))
+        ((CPPInstance*)pyobject)->PythonOwns();
+
+    return pyobject;
+}
 namespace CPyCppyy {
 // version with C type arguments only for use with Numba
 PyObject* Instance_FromVoidPtr(void* addr, const char* classname, int python_owns) {

--- a/src/CPPConstructor.cxx
+++ b/src/CPPConstructor.cxx
@@ -15,6 +15,8 @@
 //- data _____________________________________________________________________
 namespace CPyCppyy {
     extern PyObject* gNullPtrObject;
+    void* Instance_AsVoidPtr(PyObject* pyobject);
+    PyObject* Instance_FromVoidPtr(void* addr, Cppyy::TCppScope_t klass_scope, bool python_owns);
 }
 
 
@@ -44,7 +46,8 @@ PyObject* CPyCppyy::CPPConstructor::Reflex(
     if (request == Cppyy::Reflex::RETURN_TYPE) {
         std::string fn = Cppyy::GetScopedFinalName(this->GetScope());
         if (format == Cppyy::Reflex::OPTIMAL || format == Cppyy::Reflex::AS_TYPE)
-            return CreateScopeProxy(fn);
+            // return CreateScopeProxy(Cppyy::GetFinalName(this->GetScope()););
+            return Instance_FromVoidPtr(this->GetScope(), this->GetScope(), 0);
         else if (format == Cppyy::Reflex::AS_STRING)
             return CPyCppyy_PyText_FromString(fn.c_str());
     }

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -838,32 +838,6 @@ static PyObject* op_str(CPPInstance* self)
     return op_repr(self);
 }
 
-//----------------------------------------------------------------------------
-static PyObject* op_getattro(PyObject* pyobj, PyObject* pyname)
-{
-// Check if we can access the attribute at the object level
-    PyObject* attr = PyObject_GenericGetAttr(pyobj, pyname);
-    if (attr)
-        return attr;
-
-// If it's not AttributeError the attribute was found and something else failed
-    if (!PyErr_ExceptionMatches(PyExc_AttributeError))
-        return nullptr;
-
-// Keep the error aside to be used in case lookup on class level fails
-    PyObject* pytype = 0, *pyvalue = 0, *pytrace = 0;
-    PyErr_Fetch(&pytype, &pyvalue, &pytrace);
-    
-// Perform a class level lookup for statics, enums etc.
-    CPPClass* klass = (CPPClass*)Py_TYPE(pyobj);
-    attr = PyObject_GetAttr((PyObject*)klass, pyname);
-    if (attr)
-        return attr;
-    
-    PyErr_Restore(pytype, pyvalue, pytrace);
-    return nullptr;
-}
-
 //-----------------------------------------------------------------------------
 static PyObject* op_getownership(CPPInstance* pyobj, void*)
 {
@@ -1056,7 +1030,7 @@ PyTypeObject CPPInstance_Type = {
     (hashfunc)op_hash,             // tp_hash
     0,                             // tp_call
     (reprfunc)op_str,              // tp_str
-    (getattrofunc)op_getattro,     // tp_getattro
+    0,                             // tp_getattro
     0,                             // tp_setattro
     0,                             // tp_as_buffer
     Py_TPFLAGS_DEFAULT |

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -229,7 +229,7 @@ namespace Cppyy {
 
 // method/function reflection information ------------------------------------
     CPPYY_IMPORT
-    std::vector<TCppMethod_t> GetClassMethods(TCppScope_t scope);
+    void GetClassMethods(TCppScope_t scope, std::vector<TCppMethod_t> &methods);
     CPPYY_IMPORT
     std::vector<TCppScope_t> GetMethodsFromName(TCppScope_t scope, const std::string& name);
 

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -311,6 +311,9 @@ namespace Cppyy {
     CPPYY_IMPORT
     TCppType_t  GetType(const std::string& name, bool enable_slow_lookup = false);
     CPPYY_IMPORT
+    bool AppendTypesSlow(const std::string &name,
+                         std::vector<Cpp::TemplateArgInfo>& types);
+    CPPYY_IMPORT
     TCppType_t  GetComplexType(const std::string& element_type);
     CPPYY_IMPORT
     std::string GetDatamemberTypeAsString(TCppScope_t var);

--- a/src/Dispatcher.cxx
+++ b/src/Dispatcher.cxx
@@ -253,7 +253,8 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
     for (BaseInfos_t::size_type ibase = 0; ibase < base_infos.size(); ++ibase) {
         const auto& binfo = base_infos[ibase];
 
-        std::vector<Cppyy::TCppMethod_t> methods = Cppyy::GetClassMethods(binfo.btype);
+        std::vector<Cppyy::TCppMethod_t> methods;
+        Cppyy::GetClassMethods(binfo.btype, methods);
         bool cctor_found = false, default_found = false, any_ctor_found = false;
         for (auto &method : methods) {
             if (Cppyy::IsConstructor(method)) {

--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -176,9 +176,8 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass, cons
 // functions in namespaces are properly found through lazy lookup, so do not
 // create them until needed (the same is not true for data members)
     std::vector<Cppyy::TCppMethod_t> methods;
-    // FIXME: GetClassMethods should take methods as a reference to avoid copy.
-    if (isComplete)
-      methods = Cppyy::GetClassMethods(scope);
+
+    if (isComplete) Cppyy::GetClassMethods(scope, methods);
 
     for (auto &method : methods) {
 

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -493,7 +493,7 @@ static inline PyObject* SelectAndForward(TemplateProxy* pytmpl, CPPOverload* pym
 static inline PyObject* CallMethodImp(TemplateProxy* pytmpl, PyObject*& pymeth,
     CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, bool impOK, uint64_t sighash)
 {
-// Actual call of a given overload: takes care of handlign of "self" and
+// Actual call of a given overload: takes care of handling of "self" and
 // dereferences the overloaded method after use.
 
     PyObject* result;

--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -817,13 +817,13 @@ std::vector<Cpp::TemplateArgInfo> CPyCppyy::Utility::GetTemplateArgsTypes(
         PyObject* tn = justOne ? tpArgs : PyTuple_GET_ITEM(tpArgs, i);
         if (CPyCppyy_PyText_Check(tn)) {
             const char * tn_string = CPyCppyy_PyText_AsString(tn);
-            Cppyy::TCppType_t tn_type = Cppyy::GetType(tn_string, /* enable_slow_lookup */ true);
-            if (!tn_type) {
+
+            if (Cppyy::AppendTypesSlow(tn_string, types)) {
                 PyErr_Format(PyExc_SyntaxError,
-                             "Cannot find arg: %s", tn_string);
+                             "Cannot find Templated Arg: %s", tn_string);
                 return {};
             }
-            types.push_back(tn_type);
+
     // some commmon numeric types (separated out for performance: checking for
     // __cpp_name__ and/or __name__ is rather expensive)
         } else {


### PR DESCRIPTION
Some changes that fix:

`__reflex__` lookup for constructors failing with numba
Support for TemplateArgInfo and update template instantiation to use latest in InterOp pointed by clingwrapper
revert the incorrect usage of `op_getattro` for attribute lookups by the Python API
Update `GetClassMethods` to take methods as a reference instead of returning std::vector of methods

