### PR TITLE
fix: use `GetNamed` with `Namespace` instead of `CheckDatamember`

### DIFF
--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -535,7 +535,7 @@ static int meta_setattro(PyObject* pyclass, PyObject* pyname, PyObject* pyval)
     // skip if the given pyval is a descriptor already, or an unassignable class
         if (!CPyCppyy::CPPDataMember_Check(pyval) && !CPyCppyy::CPPScope_Check(pyval)) {
             std::string name = CPyCppyy_PyText_AsString(pyname);
-            if (Cppyy::CheckDatamember(((CPPScope*)pyclass)->fCppType, name))
+            if (Cppyy::GetNamed(name, ((CPPScope*)pyclass)->fCppType))
                 meta_getattro(pyclass, pyname);       // triggers creation
         }
     }


### PR DESCRIPTION
Fixes [test08_global_builtin_type](https://github.com/compiler-research/cppyy/blob/master/test/test_datatypes.py#L581-L582) and [test23_copy_constructor](https://github.com/compiler-research/cppyy/blob/master/test/test_regression.py#L591-L592).