### PR TITLE
fix logic to trim white space

### DIFF
--- a/src/TypeManip.cxx
+++ b/src/TypeManip.cxx
@@ -162,7 +162,7 @@ std::string CPyCppyy::TypeManip::compound(const std::string& name)
     std::string cleanName = remove_const(name);
     auto idx = find_qualifier_index(cleanName);
 
-    const std::string& cpd = cleanName.substr(idx, std::string::npos);
+    std::string cpd = cleanName.substr(idx, std::string::npos);
 
 // for easy identification of fixed size arrays
     if (!cpd.empty() && cpd.back() == ']') {
@@ -171,7 +171,7 @@ std::string CPyCppyy::TypeManip::compound(const std::string& name)
 
         std::ostringstream scpd;
         scpd << cpd.substr(0, cpd.find('[')) << "[]";
-        return scpd.str();
+        cpd = scpd.str();
     }
 
     // XXX: remove this hack


### PR DESCRIPTION
fixes 5 tests

---

Explanation of the change:
line 178 needs to be executed to trim extra white space. As there is a string comparison later on.