### PR TITLE
fix type conversion when scope is a typedefs

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -2055,7 +2055,10 @@ bool CPyCppyy::InstanceConverter::SetArg(
     CPPInstance* pyobj = GetCppInstance(pyobject);
     if (pyobj) {
         auto oisa = pyobj->ObjectIsA();
-        if (oisa && (oisa == fClass || Cppyy::IsSubclass(oisa, fClass))) {
+        if (oisa && ((oisa == (Cppyy::IsTypedefed(fClass)
+                                   ? Cppyy::GetUnderlyingScope(fClass)
+                                   : fClass)) ||
+                     Cppyy::IsSubclass(oisa, fClass))) {
         // calculate offset between formal and actual arguments
             para.fValue.fVoidp = pyobj->GetObject();
             if (!para.fValue.fVoidp)


### PR DESCRIPTION
Fixes 4 test cases:
`test_datatypes.py::TestDATATYPES::test34_object_pointer`,
`test_doc_features.py::TestDOCFEATURES::test_x_inheritance`,
`test_pythonify.py::TestPYTHONIFY::test10_default_arguments` &
`test_stltypes.py::TestSTLSTRING::test03_string_with_null_character`.