### PR TITLE
fix: trim space from reference typename

### DIFF
--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -903,6 +903,9 @@ CPyCppyy::Executor* CPyCppyy::CreateExecutor(Cppyy::TCppType_t type, cdims_t dim
 
 // an exactly matching executor is best
     std::string fullType = Cppyy::GetTypeAsString(type);
+    if (fullType.ends_with(" &"))
+        fullType = fullType.substr(0, fullType.size() - 2) + "&";
+
     ExecFactories_t::iterator h = gExecFactories.find(fullType);
     if (h != gExecFactories.end())
         return (h->second)(dims);


### PR DESCRIPTION
Fixes:
`test_datatypes.py::TestDATATYPES::test04_class_read_access` and `test_datatypes.py::TestDATATYPES::test05_class_data_write_access`
with https://github.com/compiler-research/cppyy-backend/pull/125