### PR TITLE
fix resolution of `std::complex`

### DIFF
--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -545,7 +545,7 @@ CPPYY_IMPL_ARRAY_EXEC(ComplexL, std::complex<long>,      )
 PyObject* CPyCppyy::Complex##code##Executor::Execute(                        \
     Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt) \
 {                                                                            \
-    static Cppyy::TCppType_t scopeid = Cppyy::GetComplexType(#type);         \
+    static Cppyy::TCppScope_t scopeid = Cppyy::GetScope("std::complex<"#type">");\
     std::complex<type>* result =                                             \
         (std::complex<type>*)GILCallO(method, self, ctxt, scopeid);          \
     if (!result) {                                                           \
@@ -567,7 +567,7 @@ PyObject* CPyCppyy::STLStringExecutor::Execute(
 // execute <method> with argument <self, ctxt>, construct python string return value
 
 // TODO: make use of GILLCallS (?!)
-    static Cppyy::TCppType_t sSTLStringScope = Cppyy::GetFullScope("std::string");
+    static Cppyy::TCppScope_t sSTLStringScope = Cppyy::GetFullScope("std::string");
     std::string* result = (std::string*)GILCallO(method, self, ctxt, sSTLStringScope);
     if (!result)
         result = new std::string{};


### PR DESCRIPTION
Old implementation returned `_Complex double` inplace of `std::complete<double>`.
Reference: https://github.com/compiler-research/cppyy/pull/135#issuecomment-2646113585

---

Using consistent types (`TCppScope_t`).