### PR TITLE
Delete unneeded pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["cppyy-cling==6.32.8", "cppyy-backend==1.15.3", "setuptools", "wheel"]


### PR DESCRIPTION
I do not believe this file is needed anymore. The ci should pass without it.