### PR TITLE
Prefix InterOp cmake options

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -477,8 +477,8 @@ jobs:
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${cling_on}" == "ON" ]]; then
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -440,8 +440,8 @@ jobs:
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${cling_on}" == "ON" ]]; then
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -377,8 +377,8 @@ jobs:
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    `
-                -DUSE_CLING=ON                                  `
-                -DUSE_REPL=OFF                                  `
+                -DCPPINTEROP_USE_CLING=ON                                  `
+                -DCPPINTEROP_USE_REPL=OFF                                  `
                 -DCling_DIR="$env:LLVM_BUILD_DIR\tools\cling"   `
                 -DLLVM_DIR="$env:LLVM_BUILD_DIR" `
                 -DLLVM_ENABLE_WERROR=On                          `

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -598,8 +598,8 @@ jobs:
         export CPPINTEROP_BUILD_DIR=$PWD
         if [[ "${cling_on}" == "ON" ]]; then
           emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
-                -DUSE_CLING=ON                                  \
-                -DUSE_REPL=OFF                                  \
+                -DCPPINTEROP_USE_CLING=ON                                  \
+                -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCMAKE_PREFIX_PATH=$PREFIX                     \
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \


### PR DESCRIPTION
Based on the change in CppInterOp: https://github.com/compiler-research/CppInterOp/pull/505 that prefixes the build option with `CPPINTEROP`