### PR TITLE
Use `GetTemplatedMethods` and fix templated functions in ProxyWrappers

### DIFF
--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -270,13 +270,12 @@ namespace Cppyy {
     std::string GetMethodPrototype(TCppMethod_t, bool show_formal_args);
     CPPYY_IMPORT
     bool        IsConstMethod(TCppMethod_t);
-
+    CPPYY_IMPORT
+    void GetTemplatedMethods(TCppScope_t scope, std::vector<TCppMethod_t> &methods);
     CPPYY_IMPORT
     TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope, bool accept_namespace = false);
     CPPYY_IMPORT
     std::string GetTemplatedMethodName(TCppScope_t scope, TCppIndex_t imeth);
-    CPPYY_IMPORT
-    bool        IsTemplatedConstructor(TCppScope_t scope, TCppIndex_t imeth);
     CPPYY_IMPORT
     bool        ExistsMethodTemplate(TCppScope_t scope, const std::string& name);
     CPPYY_IMPORT

--- a/src/Dispatcher.cxx
+++ b/src/Dispatcher.cxx
@@ -337,9 +337,10 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
 
     // support for templated ctors in single inheritance (TODO: also multi possible?)
         if (base_infos.size() == 1) {
-            const Cppyy::TCppIndex_t nTemplMethods = Cppyy::GetNumTemplatedMethods(binfo.btype);
-            for (Cppyy::TCppIndex_t imeth = 0; imeth < nTemplMethods; ++imeth) {
-                if (Cppyy::IsTemplatedConstructor(binfo.btype, imeth)) {
+                std::vector<Cppyy::TCppMethod_t> templ_methods;
+                Cppyy::GetTemplatedMethods(binfo.btype, templ_methods);
+                for (auto &method : templ_methods) {
+                if (Cppyy::IsConstructor(method)) {
                     any_ctor_found = true;
                     has_tmpl_ctors += 1;
                     break;        // one suffices to map as argument packs are used

--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -189,7 +189,9 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass, cons
     // special case trackers
         bool setupSetItem = false;
         bool isConstructor = Cppyy::IsConstructor(method);
-        bool isTemplate = isConstructor ? false : Cppyy::IsTemplatedMethod(method);
+
+    // Here isTemplate means to ignore templated constructors, that is handled in the next loop.
+        bool isTemplate = Cppyy::IsTemplatedMethod(method) && !isConstructor;
         bool isStubbedOperator = false;
 
     // filter empty names (happens for namespaces, is bug?)
@@ -225,8 +227,7 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass, cons
         }
 
     // template members; handled by adding a dispatcher to the class
-        bool storeOnTemplate = false; //XXX
-            //isTemplate ? true : (!isConstructor && Cppyy::ExistsMethodTemplate(scope, mtCppName));
+        bool storeOnTemplate = isTemplate;
         if (storeOnTemplate) {
             sync_templates(pyclass, mtCppName, mtName);
         // continue processing to actually add the method so that the proxy can find
@@ -293,14 +294,16 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass, cons
         }
     }
 
+
 // add proxies for un-instantiated/non-overloaded templated methods
-    const Cppyy::TCppIndex_t nTemplMethods = isNamespace ? 0 : Cppyy::GetNumTemplatedMethods(scope);
-    for (Cppyy::TCppIndex_t imeth = 0; imeth < nTemplMethods; ++imeth) {
-        const std::string mtCppName = Cppyy::GetTemplatedMethodName(scope, imeth);
+    std::vector<Cppyy::TCppMethod_t> templ_methods;
+    Cppyy::GetTemplatedMethods(scope, templ_methods);
+    for (auto &method : templ_methods) {
+        const std::string mtCppName = Cppyy::GetMethodName(method);
     // the number of arguments isn't known until instantiation and as far as C++ is concerned, all
     // same-named operators are simply overloads; so will pre-emptively add both names if with and
     // without arguments differ, letting the normal overload mechanism resolve on call
-        bool isConstructor = Cppyy::IsTemplatedConstructor(scope, imeth);
+        bool isConstructor = Cppyy::IsConstructor(method);
 
     // first add with no arguments
         std::string mtName0 = isConstructor ? "__init__" : Utility::MapOperatorName(mtCppName, false);


### PR DESCRIPTION
This deprecates `IsTemplatedConstructor` and performs the underlying purpose of the code block. Handle non-templated constructors and templated methods in the first loop and un-instantiated template methods and templated constructors in the second. This PR also refactors loops in Dispatcher.cxx and ProxyWrapper.cxx to no longer use index based interfaces to retrieve template method info