### PR TITLE
fix: preserve the `value_type` string

### DIFF
--- a/src/PyStrings.cxx
+++ b/src/PyStrings.cxx
@@ -59,6 +59,7 @@ PyObject* CPyCppyy::PyStrings::gTemplate         = nullptr;
 PyObject* CPyCppyy::PyStrings::gVectorAt         = nullptr;
 PyObject* CPyCppyy::PyStrings::gInsert           = nullptr;
 PyObject* CPyCppyy::PyStrings::gValueType        = nullptr;
+PyObject* CPyCppyy::PyStrings::gValueTypePtr     = nullptr;
 PyObject* CPyCppyy::PyStrings::gValueSize        = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gCppReal          = nullptr;
@@ -145,6 +146,7 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gVectorAt,       _vector__at);
     CPPYY_INITIALIZE_STRING(gInsert,         insert);
     CPPYY_INITIALIZE_STRING(gValueType,      value_type);
+    CPPYY_INITIALIZE_STRING(gValueTypePtr,   _value_type);
     CPPYY_INITIALIZE_STRING(gValueSize,      value_size);
 
     CPPYY_INITIALIZE_STRING(gCppReal,        __cpp_real);
@@ -218,6 +220,7 @@ PyObject* CPyCppyy::DestroyPyStrings() {
     Py_DECREF(PyStrings::gVectorAt);    PyStrings::gVectorAt    = nullptr;
     Py_DECREF(PyStrings::gInsert);      PyStrings::gInsert      = nullptr;
     Py_DECREF(PyStrings::gValueType);   PyStrings::gValueType   = nullptr;
+    Py_DECREF(PyStrings::gValueTypePtr);PyStrings::gValueTypePtr= nullptr;
     Py_DECREF(PyStrings::gValueSize);   PyStrings::gValueSize   = nullptr;
 
     Py_DECREF(PyStrings::gCppReal);     PyStrings::gCppReal     = nullptr;

--- a/src/PyStrings.h
+++ b/src/PyStrings.h
@@ -62,6 +62,7 @@ namespace PyStrings {
     extern PyObject* gVectorAt;
     extern PyObject* gInsert;
     extern PyObject* gValueType;
+    extern PyObject* gValueTypePtr;
     extern PyObject* gValueSize;
 
     extern PyObject* gCppReal;

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -340,7 +340,7 @@ static bool FillVector(PyObject* vecin, PyObject* args, ItemGetter* getter)
     if (fi && (PyTuple_CheckExact(fi) || PyList_CheckExact(fi))) {
     // use emplace_back to construct the vector entries one by one
         PyObject* eb_call = PyObject_GetAttrString(vecin, (char*)"emplace_back");
-        PyObject* vtype = GetAttrDirect((PyObject*)Py_TYPE(vecin), PyStrings::gValueType);
+        PyObject* vtype = GetAttrDirect((PyObject*)Py_TYPE(vecin), PyStrings::gValueTypePtr);
         bool value_is_vector = false;
         if (vtype && PyLong_Check(vtype)) {
         // if the value_type is a vector, then allow for initialization from sequences
@@ -553,7 +553,7 @@ static PyObject* vector_iter(PyObject* v) {
     if (v->ob_refcnt <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
         vi->vi_flags = vectoriterobject::kNeedLifeLine;
 
-    PyObject* pyvalue_type = PyObject_GetAttr((PyObject*)Py_TYPE(v), PyStrings::gValueType);
+    PyObject* pyvalue_type = PyObject_GetAttr((PyObject*)Py_TYPE(v), PyStrings::gValueTypePtr);
     if (pyvalue_type) {
         PyObject* pyvalue_size = GetAttrDirect((PyObject*)Py_TYPE(v), PyStrings::gValueSize);
         if (pyvalue_size) {
@@ -1839,6 +1839,9 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
             Cppyy::TCppType_t vtype = Cppyy::ResolveType(value_type);
             if (vtype) {    // actually resolved?
                 PyObject* pyvalue_type = PyLong_FromVoidPtr(vtype);
+                PyObject_SetAttr(pyclass, PyStrings::gValueTypePtr, pyvalue_type);
+                Py_DECREF(pyvalue_type);
+                pyvalue_type = PyUnicode_FromString(Cppyy::GetTypeAsString(vtype).c_str());
                 PyObject_SetAttr(pyclass, PyStrings::gValueType, pyvalue_type);
                 Py_DECREF(pyvalue_type);
             }


### PR DESCRIPTION
`value_type` was used as `QualType*`,
but to match the behaviour upstream I have modified it to string `_value_type` (`gValueTypePtr`) a new variable is now used as `QualType*`

---

Enables a test.