### PR TITLE
Complete typename utility with GetReferencedType and GetPointerType

### DIFF
--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -76,6 +76,10 @@ namespace Cppyy {
     CPPYY_IMPORT
     TCppType_t GetRealType(TCppType_t type);
     CPPYY_IMPORT
+    TCppType_t GetReferencedType(TCppType_t type, bool rvalue);
+    CPPYY_IMPORT
+    TCppType_t GetPointerType(TCppType_t type);
+    CPPYY_IMPORT
     std::string ResolveEnum(TCppScope_t enum_type);
     CPPYY_IMPORT
     TCppScope_t GetScope(const std::string& name, TCppScope_t parent_scope = 0);


### PR DESCRIPTION
This completes the `AddTypeName` function in Utility.cxx that earlier appended `&&/&/*` to strings. This was marked as a FIXME and is now fixed with this PR.

This also prevents build time warnings:

```
[ 97%] Building CXX object CMakeFiles/cppyy.dir/src/Utility.cxx.o
/home/runner/work/CPyCppyy/CPyCppyy/src/Utility.cxx: In function ‘bool AddTypeName(std::vector<Cpp::TemplateArgInfo>&, PyObject*, PyObject*, CPyCppyy::Utility::ArgPreference, int*)’:
/home/runner/work/CPyCppyy/CPyCppyy/src/Utility.cxx:727:21: warning: statement has no effect [-Wunused-value]
  727 |                     types;
      |                     ^~~~~
/home/runner/work/CPyCppyy/CPyCppyy/src/Utility.cxx:733:25: warning: statement has no effect [-Wunused-value]
  733 |                         types;
      |                         ^~~~~
/home/runner/work/CPyCppyy/CPyCppyy/src/Utility.cxx:737:25: warning: statement has no effect [-Wunused-value]
  737 |                         types;
      |                         ^~~~~
/home/runner/work/CPyCppyy/CPyCppyy/src/Utility.cxx:778:21: warning: statement has no effect [-Wunused-value]
  778 |                     types;
      |                     ^~~~~
[100%] Linking CXX shared library libcppyy.so
```