### PR TITLE
fix CPPMethod::GetPrototype according to InterOp API

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -399,11 +399,9 @@ PyObject* CPyCppyy::CPPMethod::GetPrototype(bool fa)
     // gives
     // a::b
     std::string finalscope = Cppyy::GetScopedFinalName(fScope);
-    return CPyCppyy_PyText_FromFormat("%s%s %s%s%s%s",
+    return CPyCppyy_PyText_FromFormat("%s%s %s%s",
         (Cppyy::IsStaticMethod(fMethod) ? "static " : ""),
         Cppyy::GetMethodReturnTypeAsString(fMethod).c_str(),
-        finalscope.c_str(),
-        (finalscope.empty() ? "" : "::"), // Add final set of '::' if the method is scoped in namespace(s)
         Cppyy::GetScopedFinalName(fMethod).c_str(),
         GetSignatureString(fa).c_str());
 }


### PR DESCRIPTION
helps fix 5 tests along with https://github.com/compiler-research/CppInterOp/pull/661