### PR TITLE
Reduce return type of function

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -333,13 +333,18 @@ void CPyCppyy::CPPMethod::SetPyError_(PyObject* msg)
     Py_XDECREF(msg);
 }
 
+extern std::map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
+
 //- constructors and destructor ----------------------------------------------
 CPyCppyy::CPPMethod::CPPMethod(
         Cppyy::TCppScope_t scope, Cppyy::TCppMethod_t method) :
     fMethod(method), fScope(scope), fExecutor(nullptr), fArgIndices(nullptr),
     fArgsRequired(-1)
 {
-   // empty
+    Cppyy::TCppType_t result = Cppyy::ResolveType(Cppyy::GetMethodReturnType(fMethod));
+    if (TypeReductionMap.contains(result)) {
+        fMethod = Cppyy::ReduceReturnType(fMethod, TypeReductionMap[result]);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -36,6 +36,8 @@ PyObject* Instance_FromVoidPtr(
 #include <vector>
 
 
+std::map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
+
 // Note: as of py3.11, dictionary objects no longer carry a function pointer for
 // the lookup, so it can no longer be shimmed and "from cppyy.interactive import *"
 // thus no longer works.
@@ -910,7 +912,9 @@ static PyObject* AddTypeReducer(PyObject*, PyObject* args)
     if (!PyArg_ParseTuple(args, const_cast<char*>("ss"), &reducable, &reduced))
         return nullptr;
 
-    Cppyy::AddTypeReducer(reducable, reduced);
+    Cppyy::TCppType_t reducable_type = Cppyy::GetTypeFromScope(Cppyy::GetScope(reducable));
+    Cppyy::TCppType_t reduced_type = Cppyy::GetTypeFromScope(Cppyy::GetScope(reduced));
+    TypeReductionMap[reducable_type] = reduced_type;
 
     Py_RETURN_NONE;
 }

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -324,6 +324,8 @@ namespace Cppyy {
     CPPYY_IMPORT
     std::string GetDatamemberName(TCppScope_t scope, TCppIndex_t idata);
     CPPYY_IMPORT
+    TCppScope_t ReduceReturnType(TCppScope_t fn, TCppType_t reduce);
+    CPPYY_IMPORT
     TCppType_t  GetDatamemberType(TCppScope_t var);
     CPPYY_IMPORT
     std::string GetTypeAsString(TCppType_t type);


### PR DESCRIPTION
This is done based on user defined reduction rule and using another wrapper function
Required by test01_reduce_binary

---

Depends on https://github.com/compiler-research/cppyy-backend/pull/164