### PR TITLE
Revert "fix type creation for typedef to class pointer"

### DIFF
--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -577,8 +577,9 @@ PyObject* CPyCppyy::CreateScopeProxy(const std::string& name, PyObject* parent, 
     } else if (Cppyy::TCppScope_t klass = Cppyy::GetScope(name, parent_scope)) {
         if (Cppyy::IsTypedefed(klass) &&
             Cppyy::IsPointerType(Cppyy::GetTypeFromScope(klass)) &&
-            Cppyy::IsClass(Cppyy::GetUnderlyingScope(klass)))
-            return nullptr; // this is handled by the caller; typedef to class pointer
+            Cppyy::IsClass(Cppyy::GetUnderlyingScope(klass)) &&
+            !Cppyy::IsComplete(Cppyy::GetUnderlyingScope(klass)))
+            return nullptr; // this is handled by the caller; typedef to undefined class pointer
         return CreateScopeProxy(klass, parent, flags);
     } else if (Cppyy::IsBuiltin(name)) {
         Cppyy::TCppType_t type = Cppyy::GetType(name);


### PR DESCRIPTION
Reverts compiler-research/CPyCppyy#123

I suspect #123 is the cause of the failures in https://github.com/compiler-research/cppyy-backend/pull/166 and https://github.com/compiler-research/CPyCppyy/pull/126.
#123 might be introducing some kind of memory corruption.