### PR TITLE
Add public API to decouple internal header usage in ROOT

### DIFF
--- a/include/CPyCppyy/API.h
+++ b/include/CPyCppyy/API.h
@@ -176,6 +176,10 @@ CPYCPPYY_EXTERN void* CallVoidP(Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallCo
 
 //- C++ access to cppyy objects ---------------------------------------------
 
+// Get C++ Instance (python object proxy) name.
+// Sets a TypeError and returns an empty string if the pyobject is not a CPPInstance.
+CPYCPPYY_EXTERN std::string Instance_GetScopedFinalName(PyObject* pyobject);
+
 // C++ Instance (python object proxy) to void* conversion
 CPYCPPYY_EXTERN void* Instance_AsVoidPtr(PyObject* pyobject);
 
@@ -201,6 +205,11 @@ CPYCPPYY_EXTERN bool Instance_IsLively(PyObject* pyobject);
 // type verifiers for C++ Overload
 CPYCPPYY_EXTERN bool Overload_Check(PyObject* pyobject);
 CPYCPPYY_EXTERN bool Overload_CheckExact(PyObject* pyobject);
+
+// Sets the __reduce__ method for the CPPInstance class, which is by default not
+// implemented by cppyy but might make sense to implement by frameworks that
+// support IO of arbitrary C++ objects, like ROOT.
+CPYCPPYY_EXTERN void Instance_SetReduceMethod(PyCFunction reduceMethod);
 
 
 //- access to the python interpreter ----------------------------------------

--- a/src/API.cxx
+++ b/src/API.cxx
@@ -105,6 +105,18 @@ static bool Initialize()
 
 
 //- C++ access to cppyy objects ---------------------------------------------
+std::string CPyCppyy::Instance_GetScopedFinalName(PyObject* pyobject)
+{
+   if (!Instance_Check(pyobject)) {
+       PyErr_SetString(PyExc_TypeError, "Instance_GetScopedFinalName : object is not a C++ instance");
+       return "";
+   }
+
+   Cppyy::TCppType_t pyobjectClass = ((CPPInstance *)pyobject)->ObjectIsA();
+   return Cppyy::GetScopedFinalName(pyobjectClass);
+}
+
+//-----------------------------------------------------------------------------
 void* CPyCppyy::Instance_AsVoidPtr(PyObject* pyobject)
 {
 // Extract the object pointer held by the CPPInstance pyobject.
@@ -287,6 +299,11 @@ bool CPyCppyy::Overload_CheckExact(PyObject* pyobject)
     return CPPOverload_CheckExact(pyobject);
 }
 
+//-----------------------------------------------------------------------------
+void CPyCppyy::Instance_SetReduceMethod(PyCFunction reduceMethod)
+{
+    CPPInstance::ReduceMethod() = reduceMethod;
+}
 
 //- access to the python interpreter ----------------------------------------
 bool CPyCppyy::Import(const std::string& mod_name)

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -400,6 +400,21 @@ static PySequenceMethods op_as_sequence = {
     0,                             // sq_inplace_repeat
 };
 
+PyCFunction &CPPInstance::ReduceMethod() {
+   static PyCFunction reducer = nullptr;
+   return reducer;
+}
+
+PyObject *op_reduce(PyObject *self, PyObject *args)
+{
+   auto &reducer = CPPInstance::ReduceMethod();
+   if (!reducer) {
+      PyErr_SetString(PyExc_NotImplementedError, "");
+      return nullptr;
+   }
+   return reducer(self, args);
+}
+
 
 //----------------------------------------------------------------------------
 static PyMethodDef op_methods[] = {
@@ -409,6 +424,8 @@ static PyMethodDef op_methods[] = {
       (char*)"dispatch to selected overload"},
     {(char*)"__smartptr__", (PyCFunction)op_get_smartptr, METH_NOARGS,
       (char*)"get associated smart pointer, if any"},
+    {(char*)"__reduce__",  (PyCFunction)op_reduce, METH_NOARGS,
+        (char*)"reduce method for serialization"},
     {(char*)"__reshape__",  (PyCFunction)op_reshape, METH_O,
         (char*)"cast pointer to 1D array type"},
     {(char*)nullptr, nullptr, 0, nullptr}

--- a/src/CPPInstance.h
+++ b/src/CPPInstance.h
@@ -83,6 +83,12 @@ public:
     void CastToArray(Py_ssize_t sz);
     Py_ssize_t ArrayLength();
 
+// implementation of the __reduce__ method: doesn't wrap any function by
+// default but can be re-assigned by libraries that add C++ object
+// serialization support, like ROOT
+    static PyCFunction &ReduceMethod();
+
+
 private:
     void  CreateExtension();
     void* GetExtendedObject();


### PR DESCRIPTION
From https://github.com/root-project/root/commit/2265970702a407dd09e7ff0bb01016993663f31a

Adapted to also add the ReduceMethod which was a patch in ROOT. Since this is an extra method injection, it does not change any behaviour and is purely additive which is why I think this patch can be upstreamed to our forks.