### PR TITLE
New ExecStript implementation without re-initializing Python

### DIFF
--- a/src/API.cxx
+++ b/src/API.cxx
@@ -392,117 +392,57 @@ void CPyCppyy::ExecScript(const std::string& name, const std::vector<std::string
     }
 
 // store a copy of the old cli for restoration
-    PyObject* oldargv = PySys_GetObject(const_cast<char*>("argv"));   // borrowed
-    if (!oldargv)                                 // e.g. apache
+    PyObject* oldargv = PySys_GetObject("argv");   // borrowed
+    if (oldargv) {
+        PyObject* copy = PyList_GetSlice(oldargv, 0, PyList_Size(oldargv));
+        oldargv = copy;  // now owned
+    } else {
         PyErr_Clear();
-    else {
-        PyObject* l = PyList_New(PyList_GET_SIZE(oldargv));
-        for (int i = 0; i < PyList_GET_SIZE(oldargv); ++i) {
-            PyObject* item = PyList_GET_ITEM(oldargv, i);
-            Py_INCREF(item);
-            PyList_SET_ITEM(l, i, item);          // steals ref
-        }
-        oldargv = l;
     }
 
-// create and set (add program name) the new command line
-    int argc = args.size() + 1;
-#if PY_VERSION_HEX < 0x03000000
-// This is a legacy implementation for Python 2
-    const char** argv = new const char*[argc];
-    for (int i = 1; i < argc; ++i) argv[i] = args[i-1].c_str();
-    argv[0] = Py_GetProgramName();
-    PySys_SetArgv(argc, const_cast<char**>(argv));
-    delete [] argv;
-#else
-// This is a common code block for Python 3. We prefer using objects to
-// automatize memory management and not introduce even more preprocessor
-// branching for deletion at the end of the method.
-//
-// FUTURE IMPROVEMENT ONCE OLD PYTHON VERSIONS ARE NOT SUPPORTED BY CPPYY:
-// Right now we use C++ objects to automatize memory management. One could use
-// RAAI and the Python memory allocation API (PEP 445) once some old Python
-// version is deprecated in CPPYY. That new feature is available since version
-// 3.4 and the preprocessor branching to also support that would be so
-// complicated to make the code unreadable.
-   std::vector<std::wstring> argv2;
-   argv2.reserve(argc);
-   argv2.emplace_back(name.c_str(), &name[name.size()]);
+// build new argv
+    const int argc = (int)args.size() + 1;
+    std::vector<wchar_t*> wargv(argc);
+    wargv[0] = Py_DecodeLocale(name.c_str(), nullptr);
 
-   for (int i = 1; i < argc; ++i) {
-      auto iarg = args[i - 1].c_str();
-      argv2.emplace_back(iarg, &iarg[strlen(iarg)]);
-   }
+    for (int i = 1; i < argc; ++i) {
+        wargv[i] = Py_DecodeLocale(args[i - 1].c_str(), nullptr);
+    }
 
-#if PY_VERSION_HEX < 0x03080000
-// Before version 3.8, the code is one simple line
-   wchar_t *argv2_arr[argc];
-   for (int i = 0; i < argc; ++i) {
-      argv2_arr[i] = const_cast<wchar_t *>(argv2[i].c_str());
-   }
-   PySys_SetArgv(argc, argv2_arr);
-
-#else
-// Here we comply to "PEP 587 – Python Initialization Configuration" to avoid
-// deprecation warnings at compile time.
-   class PyConfigHelperRAAI {
-   public:
-      PyConfigHelperRAAI(const std::vector<std::wstring> &argv2)
-      {
-         PyConfig_InitPythonConfig(&fConfig);
-         fConfig.parse_argv = 1;
-         UpdateArgv(argv2);
-         InitFromConfig();
-      }
-      ~PyConfigHelperRAAI() { PyConfig_Clear(&fConfig); }
-
-   private:
-      void InitFromConfig() { Py_InitializeFromConfig(&fConfig); };
-      void UpdateArgv(const std::vector<std::wstring> &argv2)
-      {
-         auto WideStringListAppendHelper = [](PyWideStringList *wslist, const wchar_t *wcstr) {
-            PyStatus append_status = PyWideStringList_Append(wslist, wcstr);
-            if (PyStatus_IsError(append_status)) {
-               std::wcerr << "Error: could not append element " << wcstr << " to arglist - " << append_status.err_msg
-                          << std::endl;
-            }
-         };
-
-#if PY_VERSION_HEX < 0x30d00f0
-         WideStringListAppendHelper(&fConfig.argv, Py_GetProgramName());
-#else
-         PyObject* progname = PySys_GetObject("executable");    // borrowed
-         wchar_t buf[4096];
-         Py_ssize_t sz = CPyCppyy_PyUnicode_AsWideChar(progname, buf, 4095);
-         if (0 < sz)
-             WideStringListAppendHelper(&fConfig.argv, buf);
-#endif
-         for (const auto &iarg : argv2) {
-            WideStringListAppendHelper(&fConfig.argv, iarg.c_str());
-         }
-      }
-      PyConfig fConfig;
-   };
-
-   PyConfigHelperRAAI pych(argv2);
-
-#endif // of the else branch of PY_VERSION_HEX < 0x03080000
-#endif // of the else branch of PY_VERSION_HEX < 0x03000000
+// set sys.argv
+    PyObject* sysmod = PyImport_ImportModule("sys");   // new reference
+    if (sysmod) {
+        PyObject* argv_obj = PyList_New(argc);
+        for (int i = 0; i < argc; ++i) {
+            PyList_SET_ITEM(argv_obj, i, PyUnicode_FromWideChar(wargv[i], -1));
+        }
+        PyObject_SetAttrString(sysmod, "argv", argv_obj);
+        Py_DECREF(argv_obj);
+        Py_DECREF(sysmod);
+    } else {
+        PyErr_Print();
+    }
 
 // actual script execution
     PyObject* gbl = PyDict_Copy(gMainDict);
     PyObject* result =       // PyRun_FileEx closes fp (b/c of last argument "1")
         PyRun_FileEx(fp, const_cast<char*>(name.c_str()), Py_file_input, gbl, gbl, 1);
+
     if (!result)
         PyErr_Print();
+
     Py_XDECREF(result);
     Py_DECREF(gbl);
 
 // restore original command line
     if (oldargv) {
-        PySys_SetObject(const_cast<char*>("argv"), oldargv);
+        PySys_SetObject("argv", oldargv);
         Py_DECREF(oldargv);
     }
+
+// free memory from Py_DecodeLocale
+    for (auto ptr : wargv)
+        PyMem_RawFree(ptr);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
New robust implementation of `ExecScript` that works for Python 3.8+ and avoids deprecated APIs.

The problem with the previous implementation was that it used `Py_InitializeFromConfig`, which should only be used once per process to initialize Python, but this already happened in the `Initialize()` method. Since this is not meant to happen, the impelentation was fragile and only worked if the original initialization was done in a certain way.

The new implementation suggested in this commit just resets `sys.argv` inplace.