### PR TITLE
Mask out non-Python limited API usage in private headers

### DIFF
--- a/src/CPPInstance.h
+++ b/src/CPPInstance.h
@@ -10,7 +10,9 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Bindings
+#ifndef Py_LIMITED_API
 #include "CPPScope.h"
+#endif
 #include "Cppyy.h"
 #include "CallContext.h"     // for Parameter
 
@@ -116,6 +118,7 @@ inline void* CPPInstance::GetObject()
         return GetExtendedObject();
 }
 
+#ifndef Py_LIMITED_API
 //----------------------------------------------------------------------------
 inline Cppyy::TCppScope_t CPPInstance::ObjectIsA(bool check_smart) const
 {
@@ -123,11 +126,12 @@ inline Cppyy::TCppScope_t CPPInstance::ObjectIsA(bool check_smart) const
     if (check_smart || !IsSmart()) return ((CPPClass*)Py_TYPE(this))->fCppType;
     return GetSmartIsA();
 }
-
+#endif
 
 //- object proxy type and type verification ----------------------------------
 CPYCPPYY_IMPORT PyTypeObject CPPInstance_Type;
 
+#ifndef Py_LIMITED_API
 template<typename T>
 inline bool CPPInstance_Check(T* object)
 {
@@ -137,6 +141,7 @@ inline bool CPPInstance_Check(T* object)
         (Py_TYPE(object)->tp_new == CPPInstance_Type.tp_new || \
          PyObject_TypeCheck(object, &CPPInstance_Type));
 }
+#endif
 
 template<typename T>
 inline bool CPPInstance_CheckExact(T* object)

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -35,6 +35,12 @@ PyObject* Instance_FromVoidPtr(
 #include <utility>
 #include <vector>
 
+#if PY_VERSION_HEX < 0x030b0000
+namespace CPyCppyy {
+extern dict_lookup_func gDictLookupOrg;
+dict_lookup_func gDictLookupOrg = nullptr;
+} // namespace CPyCppyy
+#endif
 
 std::map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
 

--- a/src/Dimensions.h
+++ b/src/Dimensions.h
@@ -1,6 +1,9 @@
 #ifndef CPYCPPYY_DIMENSIONS_H
 #define CPYCPPYY_DIMENSIONS_H
 
+// Bindings
+#include "CPyCppyy/CommonDefs.h"
+
 // Standard
 #include <algorithm>
 #include <initializer_list>

--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -25,7 +25,6 @@
 
 //- data _____________________________________________________________________
 #if PY_VERSION_HEX < 0x030b0000
-dict_lookup_func CPyCppyy::gDictLookupOrg = 0;
 bool CPyCppyy::gDictLookupActive = false;
 #endif
 

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -13,7 +13,6 @@ namespace CPyCppyy {
 class PyCallable;
 
 #if PY_VERSION_HEX < 0x030b0000
-extern dict_lookup_func gDictLookupOrg;
 extern bool gDictLookupActive;
 #endif
 
@@ -49,7 +48,11 @@ inline PyObject* CT2CppName(PyObject* pytc, const char* cpd, bool allow_voidp)
     const std::string& name = CT2CppNameS(pytc, allow_voidp);
     if (!name.empty()) {
         if (name == "const char*") cpd = "";
-        return CPyCppyy_PyText_FromString((std::string{name}+cpd).c_str());
+#if PY_VERSION_HEX < 0x03000000
+        return PyString_FromString((std::string{name}+cpd).c_str());
+#else
+        return PyUnicode_FromString((std::string{name}+cpd).c_str());
+#endif
     }
     return nullptr;
 }


### PR DESCRIPTION
Based on https://github.com/root-project/root/commit/d5a74faa2203e344c52fea8d8b9b63408ab0a6e1

Swaps out the use of CPython API functions that were not inside the limited API.
In the cases where these private headers are being used from cppyy, the parts of these headers that don't compile with the limited API are excluded via the `Py_LIMITED_API` preprocessor macro.