### PR TITLE
Add optional scope argument to Cppyy::ResolveName / Cppyy::GetType.

### DIFF
--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -73,7 +73,8 @@ namespace Cppyy {
 
 // name to opaque C++ scope representation -----------------------------------
     CPPYY_IMPORT
-    std::string ResolveName(const std::string& cppitem_name);
+    std::string ResolveName(const std::string& cppitem_name,
+                            TCppScope_t scope = nullptr);
 
     CPPYY_IMPORT
     TCppType_t ResolveEnumReferenceType(TCppType_t type);
@@ -354,7 +355,8 @@ namespace Cppyy {
     CPPYY_IMPORT
     bool IsFunctionPointerType(TCppType_t type);
     CPPYY_IMPORT
-    TCppType_t  GetType(const std::string& name, bool enable_slow_lookup = false);
+    TCppType_t  GetType(const std::string& name, bool enable_slow_lookup = false,
+                        TCppScope_t scope = nullptr);
     CPPYY_IMPORT
     bool AppendTypesSlow(const std::string &name,
                          std::vector<Cpp::TemplateArgInfo>& types,


### PR DESCRIPTION
Mirror the cppyy-backend signature change so the linker resolves the new mangled symbol. Default-arg `TCppScope_t scope = nullptr` keeps existing callers compiling unchanged; converting the four ResolveName call sites (Pythonize.cxx, Utility.cxx, Executors.cxx, Converters.cxx) to forward scope context where they have it lands separately, once the libstdc++-specific iteration-protocol path that's still failing test_stltypes test01 is identified.