### PR TITLE
Match libc++ and typedef forms in std::string pythonizations.

### DIFF
--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -1607,7 +1607,7 @@ bool run_pythonizors(PyObject* pyclass, PyObject* pyname, const std::vector<PyOb
 bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
 {
     const std::string& name = Cppyy::GetScopedFinalName(scope);
-    
+
 // Add pre-defined pythonizations (for STL and ROOT) to classes based on their
 // signature and/or class name.
     if (!pyclass)
@@ -1914,7 +1914,9 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
         Utility::AddToClass(pyclass, "__iter__", (PyCFunction)PyObject_SelfIter, METH_NOARGS);
     }
 
-    else if (name == "std::basic_string<char>") { // TODO: ask backend as well
+    else if (name == "std::basic_string<char>" ||
+             name == "std::__1::basic_string<char>" || // libc++ inline namespace
+             name == "std::string") { // typedef preserved by GetScopedFinalName on libc++
         Utility::AddToClass(pyclass, "__repr__",      (PyCFunction)STLStringRepr,       METH_NOARGS);
         Utility::AddToClass(pyclass, "__str__",       (PyCFunction)STLStringStr,        METH_NOARGS);
         Utility::AddToClass(pyclass, "__bytes__",     (PyCFunction)STLStringBytes,      METH_NOARGS);
@@ -1938,7 +1940,9 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
         ((PyTypeObject*)pyclass)->tp_hash = (hashfunc)STLStringHash;
     }
 
-    else if (name == "std::basic_string_view<char>") {
+    else if (name == "std::basic_string_view<char>" ||
+             name == "std::__1::basic_string_view<char>" || // libc++ inline namespace
+             name == "std::string_view") { // typedef preserved by GetScopedFinalName on libc++
         Utility::AddToClass(pyclass, "__real_init", "__init__");
         Utility::AddToClass(pyclass, "__init__",  (PyCFunction)StringViewInit, METH_VARARGS | METH_KEYWORDS);
         Utility::AddToClass(pyclass, "__bytes__", (PyCFunction)STLViewStringBytes,      METH_NOARGS);
@@ -1949,7 +1953,9 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
         Utility::AddToClass(pyclass, "__str__",   (PyCFunction)STLViewStringStr,        METH_NOARGS);
     }
 
-    else if (name == "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >") {
+    else if (name == "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >" ||
+             name == "std::__1::basic_string<wchar_t,std::__1::char_traits<wchar_t>,std::__1::allocator<wchar_t> >" ||
+             name == "std::wstring") {
         Utility::AddToClass(pyclass, "__repr__",  (PyCFunction)STLWStringRepr,       METH_NOARGS);
         Utility::AddToClass(pyclass, "__str__",   (PyCFunction)STLWStringStr,        METH_NOARGS);
         Utility::AddToClass(pyclass, "__bytes__", (PyCFunction)STLWStringBytes,      METH_NOARGS);


### PR DESCRIPTION
Pythonize() decides which STL pythonizations (`__eq__`, `__str__`, `__repr__`, ...) to install on a Python class by literal-string matching the result of Cppyy::GetScopedFinalName against `"std::basic_string<char>"`, `"std::basic_string_view<char>"`, and the long form for wstring. On libc++ the canonical name carries the `__1` inline namespace, and in many code paths the pretty- printer preserves the `std::string` typedef rather than unwinding to `std::basic_string<char>`. Neither form matches, so std::string returns from cppdef'd code on macOS bind as plain CPPInstances -- `mouse.make_sound() == 'peep!'` falls through to default object identity comparison and returns False
(test_doc_features::test07_run_zoo).

Add the libc++ inline-namespace variant and the bare typedef form to each of the three string-class branches. Same shape as the existing complex<double> entry above which already carries both `complex<double>` and `std::complex<double>`. Stop-gap; the right fix is to compare scope pointers (Cppyy::GetScope cached once at startup) instead of pretty-printed strings -- tracked separately.