### PR TITLE
Rework `FunctionPointerConverter` to use `FunctionProtoType` instead of strings

### DIFF
--- a/src/CPPMethod.h
+++ b/src/CPPMethod.h
@@ -73,6 +73,10 @@ public:
 
     int       GetArgMatchScore(PyObject* args_tuple) override;
 
+    bool IsSimilarFnType(Cppyy::TCppType_t fn_type) override { 
+        return Cppyy::IsSimilarFnTypes(fn_type, Cppyy::GetTypeFromScope(fMethod));
+    }
+
 public:
     PyObject* Call(CPPInstance*& self,
         CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -1,5 +1,6 @@
 // Bindings
 #include "CPyCppyy.h"
+#include "Cppyy.h"
 #include "DeclareConverters.h"
 #include "CallContext.h"
 #include "CPPExcInstance.h"
@@ -29,6 +30,7 @@
 #include <sstream>
 #include <cstddef>
 #include <string_view>
+#include <vector>
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -59,9 +61,6 @@ namespace CPyCppyy {
 // special objects
     extern PyObject* gNullPtrObject;
     extern PyObject* gDefaultObject;
-
-// regular expression for matching function pointer
-    static std::regex s_fnptr("\\((\\w*:*)*\\*&*\\)");
 }
 
 // Define our own PyUnstable_Object_IsUniqueReferencedTemporary function if the
@@ -2706,6 +2705,23 @@ static std::map<RetSigKey_t, std::map<PyObject*, void*>> sWrapperLookup;
 static std::map<PyObject*, std::pair<void*, RetSigKey_t>> sWrapperWeakRefs;
 static std::map<void*, PyObject**> sWrapperReference;
 
+static void GetSignatureFromFnType(Cppyy::TCppType_t fn_type, std::string& ret, std::string& sig) {
+    std::vector<Cppyy::TCppType_t> types;
+    Cppyy::GetFnTypeSig(fn_type, types);
+    assert(types.size() >= 1);
+    ret = Cppyy::GetTypeAsString(types[0]);
+    sig = "(";
+    bool f = false;
+    for (size_t i = 1; i < types.size(); i++) {
+        if (f)
+            sig += ", ";
+        else
+            f = true;
+        sig += Cppyy::GetTypeAsString(types[i]);
+    }
+    sig += ")";
+}
+
 static PyObject* WrapperCacheEraser(PyObject*, PyObject* pyref)
 {
     auto ipos = sWrapperWeakRefs.find(pyref);
@@ -2734,17 +2750,11 @@ static PyMethodDef gWrapperCacheEraserMethodDef = {
 };
 
 static void* PyFunction_AsCPointer(PyObject* pyobject,
-    const std::string& rettype, const std::string& signature, bool allowCppInstance)
+    const Cppyy::TCppType_t fn_type, bool allowCppInstance)
 {
 // Convert a bound C++ function pointer or callable python object to a C-style
 // function pointer. The former is direct, the latter involves a JIT-ed wrapper.
     static PyObject* sWrapperCacheEraser = PyCFunction_New(&gWrapperCacheEraserMethodDef, nullptr);
-
-    // FIXME: avoid string comparisons and parsing
-    std::string true_signature = signature;
-
-    if (true_signature.rfind("(void)") != std::string::npos)
-        true_signature = true_signature.substr(0, true_signature.size() - 6) + "()";
 
     using namespace CPyCppyy;
 
@@ -2755,17 +2765,11 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
 
     // find the overload with matching signature
         for (auto& m : ol->fMethodInfo->fMethods) {
-            PyObject* sig = m->GetSignature(false);
-            bool found = true_signature == CPyCppyy_PyText_AsString(sig);
-            Py_DECREF(sig);
-            if (found) {
+            if (m->IsSimilarFnType(fn_type)) {
                 void* fptr = (void*)m->GetFunctionAddress();
                 if (fptr) return fptr;
-                break;  // fall-through, with calling through Python
             }
         }
-        // FIXME: maybe we should try BestOverloadFunctionMatch before failing
-        // FIXME: Should we fall-through, with calling through Python
         return nullptr;
     }
 
@@ -2776,12 +2780,14 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
         if (pytmpl->fTemplateArgs)
             fullname += CPyCppyy_PyText_AsString(pytmpl->fTemplateArgs);
         Cppyy::TCppScope_t scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
-        Cppyy::TCppMethod_t cppmeth = Cppyy::GetMethodTemplate(scope, fullname, true_signature);
+        std::string ret{}, sig{};
+        GetSignatureFromFnType(fn_type, ret, sig);
+        Cppyy::TCppMethod_t cppmeth = 
+            Cppyy::GetMethodTemplate(scope, fullname, sig.substr(1, sig.size() - 2));
         if (cppmeth) {
             void* fptr = (void*)Cppyy::GetFunctionAddress(cppmeth, false);
             if (fptr) return fptr;
         }
-        // FIXME: Should we fall-through, with calling through Python
         return nullptr;
     }
 
@@ -2798,8 +2804,12 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
     // function pointers, but only to std::function.
         void* wpraddress = nullptr;
 
+        std::string ret{}, sig{};
+        GetSignatureFromFnType(fn_type, ret, sig);
+        sig = "(void)" == sig ? "()" : sig;
+
     // re-use existing wrapper if possible
-        auto key = rettype+true_signature;
+        auto key = ret+sig;
         const auto& lookup = sWrapperLookup.find(key);
         if (lookup != sWrapperLookup.end()) {
             const auto& existing = lookup->second.find(pyobject);
@@ -2827,7 +2837,7 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
                 return nullptr;
 
         // extract argument types
-            const std::vector<std::string>& argtypes = TypeManip::extract_arg_types(true_signature);
+            const std::vector<std::string>& argtypes = TypeManip::extract_arg_types(sig);
             int nArgs = (int)argtypes.size();
 
         // wrapper name
@@ -2837,7 +2847,7 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
        // build wrapper function code
             std::ostringstream code;
             code << "namespace __cppyy_internal {\n  "
-                 << rettype << " " << wname.str() << "(";
+                 << ret << " " << wname.str() << "(";
             for (int i = 0; i < nArgs; ++i) {
                 code << argtypes[i] << " arg" << i;
                 if (i != nArgs-1) code << ", ";
@@ -2846,7 +2856,7 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
                 << "    CPyCppyy::PythonGILRAII python_gil_raii;\n";
 
         // start function body
-            Utility::ConstructCallbackPreamble(rettype, argtypes, code);
+            Utility::ConstructCallbackPreamble(ret, argtypes, code);
 
         // create a referenceable pointer
             PyObject** ref = new PyObject*{pyobject};
@@ -2861,7 +2871,7 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
                     "    else PyErr_SetString(PyExc_TypeError, \"callable was deleted\");\n";
 
         // close
-            Utility::ConstructCallbackReturn(rettype, nArgs, code);
+            Utility::ConstructCallbackReturn(ret, nArgs, code);
 
         // end of namespace
             code << "}";
@@ -2901,7 +2911,7 @@ bool CPyCppyy::FunctionPointerConverter::SetArg(
     }
 
 // normal case, get a function pointer
-    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature, fAllowCppInstance);
+    void* fptr = PyFunction_AsCPointer(pyobject, fFnType, fAllowCppInstance);
     if (fptr) {
         SetLifeLine(ctxt->fPyContext, pyobject, (intptr_t)this);
         para.fValue.fVoidp = fptr;
@@ -2917,8 +2927,11 @@ PyObject* CPyCppyy::FunctionPointerConverter::FromMemory(void* address)
 // A function pointer in clang is represented by a Type, not a FunctionDecl and it's
 // not possible to get the latter from the former: the backend will need to support
 // both. Since that is far in the future, we'll use a std::function instead.
-    if (address)
-        return Utility::FuncPtr2StdFunction(fRetType, fSignature, *(void**)address);
+    if (address) {
+        std::string ret{}, sig{};
+        GetSignatureFromFnType(fFnType, ret, sig);
+        return Utility::FuncPtr2StdFunction(ret, sig, *(void**)address);
+    }
     PyErr_SetString(PyExc_TypeError, "can not convert null function pointer");
     return nullptr;
 }
@@ -2933,7 +2946,7 @@ bool CPyCppyy::FunctionPointerConverter::ToMemory(
     }
 
 // normal case, get a function pointer
-    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature, fAllowCppInstance);
+    void* fptr = PyFunction_AsCPointer(pyobject, fFnType, fAllowCppInstance);
     if (fptr) {
         SetLifeLine(ctxt, pyobject, (intptr_t)address);
         *((void**)address) = fptr;
@@ -3441,7 +3454,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
                 auto sz1 = pos1-pos-14;
                 if (resolvedType[pos+14+sz1-1] == ' ') sz1 -= 1;
 
-                return new StdFunctionConverter(cnv,
+                return new StdFunctionConverter(cnv, Cppyy::GetType(fullType),
                     resolvedType.substr(pos+14, sz1), resolvedType.substr(pos1, pos2-pos1+1));
             } else if (cnv->HasState())
                 delete cnv;
@@ -3497,13 +3510,10 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
                 result = selectInstanceCnv(klass, cpd, dims, isConst, control);
         }
     } else {
-        std::smatch sm;
-        if (std::regex_search(resolvedType, sm, s_fnptr)) {
-        // this is a function pointer
-            auto pos1 = sm.position(0);
-            auto pos2 = resolvedType.rfind(')');
-            result = new FunctionPointerConverter(
-                resolvedType.substr(0, pos1), resolvedType.substr(pos1+sm.length(), pos2-1));
+        Cppyy::TCppType_t typ = Cppyy::GetType(fullType);
+        if (Cppyy::IsFunctionType(typ)) {
+        // this is a function pointer or reference
+            result = new FunctionPointerConverter(typ);
         }
     }
     const std::string failure_msg("Failed to convert type: " + fullType + "; resolved: " + resolvedType + "; real: " + realType + "; cpd: " + cpd);
@@ -3669,7 +3679,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
                 if (resolvedTypeStr[pos+14+sz1-1] == ' ') sz1 -= 1;
 
                 const std::string &argsStr = resolvedTypeStr.substr(pos1, pos2-pos1+1).c_str();
-                return new StdFunctionConverter(cnv,
+                return new StdFunctionConverter(cnv, resolvedType,
                     resolvedTypeStr.substr(pos+14, sz1), argsStr == "(void)"? "()" : argsStr);
             } else if (cnv->HasState())
                 delete cnv;
@@ -3679,16 +3689,9 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t d
 // converters for known C++ classes and default (void*)
     Converter* result = nullptr;
     Cppyy::TCppScope_t klass = Cppyy::GetScopeFromType(realType);
-    if (resolvedTypeStr.find("(*)") != std::string::npos ||
-               (resolvedTypeStr.find("::*)") != std::string::npos)) {
-    // this is a function function pointer
-    // TODO: find better way of finding the type
-        auto pos1 = resolvedTypeStr.find('(');
-        auto pos2 = resolvedTypeStr.find("*)");
-        auto pos3 = resolvedTypeStr.rfind(')');
-        std::string return_type = resolvedTypeStr.substr(0, pos1);
-        result = new FunctionPointerConverter(
-            return_type.erase(return_type.find_last_not_of(" ") + 1), resolvedTypeStr.substr(pos2+2, pos3-pos2-1));
+    if (Cppyy::IsFunctionType(resolvedType)) {
+    // this is a function function pointer or reference
+        result = new FunctionPointerConverter(resolvedType);
     } else if ((realTypeStr != "std::byte") && (klass || (klass = Cppyy::GetFullScope(realTypeStr)))) {
         // std::byte is a special enum class used to access raw memory
         Cppyy::TCppType_t raw{0};

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -287,6 +287,16 @@ namespace Cppyy {
     CPPYY_IMPORT
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     CPPYY_IMPORT
+    bool IsFunctionType(TCppType_t typ);
+    CPPYY_IMPORT
+    TCppType_t GetFnTypeFromStdFn(TCppType_t fn_type);
+    CPPYY_IMPORT
+    void GetFnTypeSig(TCppType_t fn_type, std::vector<TCppType_t>& arg_types);
+    CPPYY_IMPORT
+    bool IsSameType(TCppType_t typ1, TCppType_t typ2);
+    CPPYY_IMPORT
+    bool IsSimilarFnTypes(TCppType_t typ1, TCppType_t typ2);
+    CPPYY_IMPORT
     std::string GetMethodSignature(TCppMethod_t, bool show_formal_args, TCppIndex_t max_args = (TCppIndex_t)-1);
     CPPYY_IMPORT
     std::string GetMethodPrototype(TCppMethod_t, bool show_formal_args);

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -3,6 +3,7 @@
 
 // Bindings
 #include "Converters.h"
+#include "Cppyy.h"
 #include "Dimensions.h"
 
 // Standard
@@ -405,8 +406,8 @@ public:
 // function pointers
 class FunctionPointerConverter : public Converter {
 public:
-    FunctionPointerConverter(const std::string& ret, const std::string& sig) :
-        fRetType(ret), fSignature(sig) {}
+    FunctionPointerConverter(Cppyy::TCppType_t FnType) :
+        fFnType(FnType) {}
 
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
@@ -416,16 +417,15 @@ public:
     virtual std::string GetFailureMsg() { return "[FunctionPointerConverter]"; };
 
 protected:
-    std::string fRetType;
-    std::string fSignature;
+    Cppyy::TCppType_t fFnType;
     bool fAllowCppInstance = false;
 };
 
 // std::function
 class StdFunctionConverter : public FunctionPointerConverter {
 public:
-    StdFunctionConverter(Converter* cnv, const std::string& ret, const std::string& sig) :
-        FunctionPointerConverter(ret, sig), fConverter(cnv) {
+    StdFunctionConverter(Converter* cnv, Cppyy::TCppType_t fn, const std::string& ret, const std::string& sig) :
+        FunctionPointerConverter(Cppyy::GetFnTypeFromStdFn(fn)), fRetType(ret), fSignature(sig), fConverter(cnv) {
         fAllowCppInstance = true;
     }
     StdFunctionConverter(const StdFunctionConverter&) = delete;
@@ -439,6 +439,8 @@ public:
     virtual std::string GetFailureMsg() { return "[StdFunctionConverter]"; };
 
 protected:
+    std::string fRetType;
+    std::string fSignature;
     Converter* fConverter;
 };
 

--- a/src/PyCallable.h
+++ b/src/PyCallable.h
@@ -6,6 +6,7 @@
 // Bindings
 #include "CPyCppyy/Reflex.h"
 #include "CallContext.h"
+#include "Cppyy.h"
 
 
 namespace CPyCppyy {
@@ -43,6 +44,8 @@ public:
     virtual PyCallable* Clone() = 0;
 
     virtual int GetArgMatchScore(PyObject* /* args_tuple */) { return INT_MAX; }
+
+    virtual bool IsSimilarFnType([[maybe_unused]] Cppyy::TCppType_t fn_type) { return false; }
 
 public:
     virtual PyObject* Call(CPPInstance*& self,


### PR DESCRIPTION
Depends on https://github.com/compiler-research/cppyy-backend/pull/208

Might need a clean up. Will do it tomorrow and remove the draft.