### PR TITLE
Look up converters by canonical type, not just spelling.

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -29,6 +29,9 @@
 #include <sstream>
 #include <cstddef>
 #include <string_view>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -55,6 +58,14 @@ namespace CPyCppyy {
 // factories
     typedef std::map<std::string, cf_t> ConvFactories_t;
     static ConvFactories_t gConvFactories;
+
+// Canonical TCppType_t -> cf_t projection of gConvFactories. Built
+// lazily and dropped whenever the public Register*/UnregisterConverter
+// API mutates the source so the cache cannot go stale.
+    typedef std::unordered_map<Cppyy::TCppType_t, cf_t> ConvFactoriesByType_t;
+    static ConvFactoriesByType_t gConvFactoriesByType;
+    static std::mutex gConvFactoriesByTypeMutex;
+    static bool gConvFactoriesByTypePopulated = false;
 
 // special objects
     extern PyObject* gNullPtrObject;
@@ -3537,6 +3548,46 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
 CPYCPPYY_EXPORT
 CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t dims)
 {
+// Canonical-identity primary lookup. The string ladder below stays as
+// the fallback for decoration-policy cases (drop const, array decay,
+// T&& -> const T&) that aren't yet expressible as QT transforms.
+//
+// Lock covers population and lookup so a concurrent
+// Register*/UnregisterConverter can't catch the cache mid-rebuild.
+// Alias-collision skip: two spellings, same TCppType_t, different
+// cf_t -- can't choose one, so leave the pair on the string path.
+    cf_t qt_fac = nullptr;
+    {
+        std::lock_guard<std::mutex> _L(gConvFactoriesByTypeMutex);
+        if (!gConvFactoriesByTypePopulated) {
+            std::unordered_map<Cppyy::TCppType_t, cf_t> first_seen;
+            std::unordered_set<Cppyy::TCppType_t> ambiguous;
+            for (const auto& kv : gConvFactories) {
+                Cppyy::TCppType_t qt = nullptr;
+                try {
+                    qt = Cppyy::GetType(kv.first, /*enable_slow_lookup=*/true);
+                } catch (const std::exception&) {
+                    continue;  // pseudo-type spelling (e.g. SCharAsInt).
+                }
+                if (!qt) continue;
+                auto it = first_seen.find(qt);
+                if (it == first_seen.end())
+                    first_seen.emplace(qt, kv.second);
+                else if (it->second != kv.second)
+                    ambiguous.insert(qt);
+            }
+            for (const auto& kv : first_seen)
+                if (!ambiguous.count(kv.first))
+                    gConvFactoriesByType.emplace(kv.first, kv.second);
+            gConvFactoriesByTypePopulated = true;
+        }
+        auto h = gConvFactoriesByType.find(type);
+        if (h != gConvFactoriesByType.end())
+            qt_fac = h->second;
+    }
+    if (qt_fac)
+        return qt_fac(dims);
+
 // The matching of the fulltype to a converter factory goes through up to five levels:
 //   1) full, exact match
 //   2) match of decorated, unqualified type
@@ -3759,6 +3810,15 @@ void CPyCppyy::DestroyConverter(Converter* p)
 }
 
 //----------------------------------------------------------------------------
+namespace CPyCppyy {
+// Drop the QT projection so CreateConverter rebuilds it on next call.
+static void InvalidateConvFactoriesByType() {
+    std::lock_guard<std::mutex> _L(gConvFactoriesByTypeMutex);
+    gConvFactoriesByType.clear();
+    gConvFactoriesByTypePopulated = false;
+}
+} // namespace CPyCppyy
+
 CPYCPPYY_EXPORT
 bool CPyCppyy::RegisterConverter(const std::string& name, cf_t fac)
 {
@@ -3768,6 +3828,7 @@ bool CPyCppyy::RegisterConverter(const std::string& name, cf_t fac)
         return false;
 
     gConvFactories[name] = fac;
+    InvalidateConvFactoriesByType();
     return true;
 }
 
@@ -3785,6 +3846,7 @@ bool CPyCppyy::RegisterConverterAlias(const std::string& name, const std::string
         return false;
 
     gConvFactories[name] = t->second;
+    InvalidateConvFactoriesByType();
     return true;
 }
 
@@ -3796,6 +3858,7 @@ bool CPyCppyy::UnregisterConverter(const std::string& name)
     auto f = gConvFactories.find(name);
     if (f != gConvFactories.end()) {
         gConvFactories.erase(f);
+        InvalidateConvFactoriesByType();
         return true;
     }
     return false;


### PR DESCRIPTION
CreateConverter(TCppType_t) discards the canonical-type identity its caller already has and falls into the same string-keyed ladder the std::string overload uses. Typedef pairs the compiler already collapsed to a single type still pay separate string searches per spelling, and the binding has no way to compare types by identity even when the AST hands it a canonical handle.

Project gConvFactories into a TCppType_t -> cf_t map, populated lazily and invalidated on every Register* / UnregisterConverter call. CreateConverter consults it first by pointer-identity; on miss, falls through to the existing string ladder unchanged, so no converter goes missing.

cppyy intentionally wires some alias-equivalent spellings to different converters -- `unsigned char` keeps 1-char-str semantics while `uint8_t` is integer-valued, even though both canonicalize to the same TCppType_t. The QT-keyed projection cannot represent that choice, so the populator detects such pairs and leaves them on the spelling-keyed path. Locked in by test_datatypes.py::test55_qt_cache_alias_collision in cppyy.