### PR TITLE
Centralize scalar marshaling in MarshalScalar.h.

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -13,6 +13,7 @@
 #include "TemplateProxy.h"
 #include "TupleOfInstances.h"
 #include "TypeManip.h"
+#include "MarshalScalar.h"
 #include "Utility.h"
 
 // Standard
@@ -390,72 +391,12 @@ static inline bool StrictBool(PyObject* pyobject, CPyCppyy::CallContext* ctxt)
     return true;
 }
 
-static inline bool CPyCppyy_PyLong_AsBool(PyObject* pyobject)
-{
-// range-checking python integer to C++ bool conversion
-    long l = PyLong_AsLong(pyobject);
-// fail to pass float -> bool; the problem is rounding (0.1 -> 0 -> False)
-    if (!(l == 0|| l == 1) || PyFloat_Check(pyobject)) {
-        PyErr_SetString(PyExc_ValueError, "boolean value should be bool, or integer 1 or 0");
-        return (bool)-1;
-    }
-    return (bool)l;
-}
+// CPyCppyy_PyLong_As{Bool,Int8,UInt8,Short,UShort,StrictInt,StrictLong,
+// StrictLongLong} were the per-T validators the scalar Converter family
+// called as F2 before #61 migrated them to MarshalScalar.h's
+// MarshalFromPyStrict<T>. Deleted in this commit; the spec lives in the
+// header now.
 
-
-// range-checking python integer to C++ integer conversion (prevents p2.7 silent conversions)
-#define CPPYY_PYLONG_AS_TYPE(name, type, limit_low, limit_high)              \
-static inline type CPyCppyy_PyLong_As##name(PyObject* pyobject)              \
-{                                                                            \
-    if (!(PyLong_Check(pyobject) || PyInt_Check(pyobject))) {                \
-        if (pyobject == CPyCppyy::gDefaultObject)                            \
-            return (type)0;                                                  \
-        PyErr_SetString(PyExc_TypeError, #type" conversion expects an integer object");\
-        return (type)-1;                                                     \
-    }                                                                        \
-    long l = PyLong_AsLong(pyobject);                                        \
-    if (l < limit_low || limit_high < l) {                                   \
-        PyErr_Format(PyExc_ValueError, "integer %ld out of range for "#type, l);\
-        return (type)-1;                                                     \
-    }                                                                        \
-    return (type)l;                                                          \
-}
-
-CPPYY_PYLONG_AS_TYPE(UInt8,     uint8_t,        0,         UCHAR_MAX)
-CPPYY_PYLONG_AS_TYPE(Int8,      int8_t,         SCHAR_MIN, SCHAR_MAX)
-CPPYY_PYLONG_AS_TYPE(UShort,    unsigned short, 0,         USHRT_MAX)
-CPPYY_PYLONG_AS_TYPE(Short,     short,          SHRT_MIN,  SHRT_MAX)
-CPPYY_PYLONG_AS_TYPE(StrictInt, int,            INT_MIN,   INT_MAX)
-
-static inline long CPyCppyy_PyLong_AsStrictLong(PyObject* pyobject)
-{
-// strict python integer to C++ long integer conversion
-
-// prevent float -> long (see CPyCppyy_PyLong_AsStrictInt)
-    if (!(PyLong_Check(pyobject) || PyInt_Check(pyobject))) {
-        if (pyobject == CPyCppyy::gDefaultObject)
-            return (long)0;
-        PyErr_SetString(PyExc_TypeError, "int/long conversion expects an integer object");
-        return (long)-1;
-    }
-
-    return (long)PyLong_AsLong(pyobject);   // already does long range check
-}
-
-static inline PY_LONG_LONG CPyCppyy_PyLong_AsStrictLongLong(PyObject* pyobject)
-{
-// strict python integer to C++ long long integer conversion
-
-// prevent float -> long (see CPyCppyy_PyLong_AsStrictInt)
-    if (!(PyLong_Check(pyobject) || PyInt_Check(pyobject))) {
-        if (pyobject == CPyCppyy::gDefaultObject)
-            return (PY_LONG_LONG)0;
-        PyErr_SetString(PyExc_TypeError, "int/long conversion expects an integer object");
-        return (PY_LONG_LONG)-1;
-    }
-
-    return PyLong_AsLongLong(pyobject);     // already does long range check
-}
 
 
 //- helper for pointer/array/reference conversions ---------------------------
@@ -481,8 +422,9 @@ static inline bool CArraySetArg(
     else {
         Py_ssize_t buflen = CPyCppyy::Utility::GetBuffer(pyobject, tc, size, para.fValue.fVoidp, check);
         if (!buflen) {
-        // stuck here as it's the least common
-            if (CPyCppyy_PyLong_AsStrictInt(pyobject) == 0)
+        // stuck here as it's the least common; probe for an int that's zero
+            int probe = 0;
+            if (CPyCppyy::MarshalFromPyStrict<int>(pyobject, probe) && probe == 0)
                 para.fValue.fVoidp = nullptr;
             else {
                 PyErr_Format(PyExc_TypeError,     // ValueError?
@@ -578,10 +520,16 @@ bool CPyCppyy::Converter::ToMemory(PyObject*, void*, PyObject* /* ctxt */)
 
 
 //- helper macro's -----------------------------------------------------------
-#define CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, F1, F2, tc)\
-/* convert <pyobject> to C++ 'type', set arg for call */                     \
-    type val = (type)F2(pyobject);                                           \
-    if (val == (type)-1 && PyErr_Occurred()) {                               \
+// MarshalFromPyStrict<type> mirrors the F2-validator contract
+// (range-check + float-reject + gDefaultObject -> 0 for int family).
+// The ctypes fallback and the outer gDefaultObject branch survive --
+// the latter still catches bool / float where MarshalFromPyStrict
+// matches CPyCppyy_PyLong_AsBool / PyFloat_AsDouble (no internal
+// gDefaultObject handling). F1 / F2 macro args are unused now; 3c
+// drops them from the wrapper macros + call sites.
+#define CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, tc)        \
+    type val;                                                                \
+    if (!MarshalFromPyStrict<type>(pyobject, val)) {                         \
         static PyTypeObject* ctypes_type = nullptr;                          \
         if (!ctypes_type) {                                                  \
             auto error = CPyCppyy::Utility::FetchPyError();                  \
@@ -601,56 +549,61 @@ bool CPyCppyy::Converter::ToMemory(PyObject*, void*, PyObject* /* ctxt */)
     para.fTypeCode = tc;                                                     \
     return true;
 
-#define CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype, F1, F2) \
+// FromMemory routes through MarshalScalar.h's MarshalToPy<type> -- the
+// per-T PyLong_FromLong / PyFloat_FromDouble / PyBool_FromLong dispatch
+// lives in one place now. ToMemory keeps F2 because F2's range-checking
+// + float-to-int rejection (CPyCppyy_PyLong_AsInt8 etc.) is stricter
+// than MarshalFromPy; the strict-marshal variants are a follow-up.
+// ToMemory routes through MarshalScalar.h's MarshalFromPyStrict<type>
+// which mirrors the CPyCppyy_PyLong_As* validator contract (range-check
+// + float-reject + gDefaultObject -> 0). F2 disappears from this macro;
+// the wrapper macros (_NI, _IB, _NB) still take F2 because SetArg uses
+// it through CPPYY_IMPL_BASIC_CONVERTER_BODY.
+#define CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype)         \
 PyObject* CPyCppyy::name##Converter::FromMemory(void* address)               \
 {                                                                            \
-    return F1((stype)*((type*)address));                                     \
+    return MarshalToPy<type>(*((type*)address));                             \
 }                                                                            \
                                                                              \
 bool CPyCppyy::name##Converter::ToMemory(                                    \
     PyObject* value, void* address, PyObject* /* ctxt */)                    \
 {                                                                            \
-    type s = (type)F2(value);                                                \
-    if (s == (type)-1 && PyErr_Occurred()) {                                 \
-        if (value == CPyCppyy::gDefaultObject) {                             \
-            PyErr_Clear();                                                   \
-            s = (type)0;                                                     \
-        } else                                                               \
-            return false;                                                    \
-    }                                                                        \
-    *((type*)address) = (type)s;                                             \
+    type s;                                                                  \
+    if (!MarshalFromPyStrict<type>(value, s))                                \
+        return false;                                                        \
+    *((type*)address) = s;                                                   \
     return true;                                                             \
 }
 
-#define CPPYY_IMPL_BASIC_CONVERTER_NI(name, type, stype, ctype, F1, F2, tc)  \
+#define CPPYY_IMPL_BASIC_CONVERTER_NI(name, type, stype, ctype, tc)          \
 bool CPyCppyy::name##Converter::SetArg(                                      \
     PyObject* pyobject, Parameter& para, CallContext* ctxt)                  \
 {                                                                            \
     if (!StrictBool(pyobject, ctxt))                                         \
         return false;                                                        \
-    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, F1, F2, tc)    \
+    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, tc)            \
 }                                                                            \
-CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype, F1, F2)
+CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype)
 
-#define CPPYY_IMPL_BASIC_CONVERTER_IB(name, type, stype, ctype, F1, F2, tc)  \
+#define CPPYY_IMPL_BASIC_CONVERTER_IB(name, type, stype, ctype, tc)          \
 bool CPyCppyy::name##Converter::SetArg(                                      \
     PyObject* pyobject, Parameter& para, CallContext* ctxt)                  \
 {                                                                            \
     if (!ImplicitBool(pyobject, ctxt))                                       \
         return false;                                                        \
-    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, F1, F2, tc)    \
+    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, tc)            \
 }                                                                            \
-CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype, F1, F2)
+CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype)
 
-#define CPPYY_IMPL_BASIC_CONVERTER_NB(name, type, stype, ctype, F1, F2, tc)  \
+#define CPPYY_IMPL_BASIC_CONVERTER_NB(name, type, stype, ctype, tc)          \
 bool CPyCppyy::name##Converter::SetArg(                                      \
     PyObject* pyobject, Parameter& para, CallContext* /*ctxt*/)              \
 {                                                                            \
     if (PyBool_Check(pyobject))                                              \
         return false;                                                        \
-    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, F1, F2, tc)    \
+    CPPYY_IMPL_BASIC_CONVERTER_BODY(name, type, stype, ctype, tc)            \
 }                                                                            \
-CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype, F1, F2)
+CPPYY_IMPL_BASIC_CONVERTER_METHODS(name, type, stype, ctype)
 
 //----------------------------------------------------------------------------
 static inline int ExtractChar(PyObject* pyobject, const char* tname, int low, int high)
@@ -702,12 +655,15 @@ PyObject* CPyCppyy::name##RefConverter::FromMemory(void* ptr)                \
 }
 
 //----------------------------------------------------------------------------
-#define CPPYY_IMPL_BASIC_CONST_REFCONVERTER(name, type, ctype, F1)           \
+// Const ref-converter SetArg through MarshalFromPyStrict<type>. The
+// outer gDefaultObject branch survives for bool / float where strict()
+// doesn't handle it internally.
+#define CPPYY_IMPL_BASIC_CONST_REFCONVERTER(name, type, ctype)               \
 bool CPyCppyy::Const##name##RefConverter::SetArg(                            \
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)            \
 {                                                                            \
-    type val = (type)F1(pyobject);                                           \
-    if (val == (type)-1 && PyErr_Occurred()) {                               \
+    type val;                                                                \
+    if (!MarshalFromPyStrict<type>(pyobject, val)) {                         \
         if (pyobject == CPyCppyy::gDefaultObject) {                          \
             PyErr_Clear();                                                   \
             val = (type)0;                                                   \
@@ -794,7 +750,7 @@ bool CPyCppyy::name##Converter::ToMemory(                                    \
 
 
 //- converters for built-ins -------------------------------------------------
-CPPYY_IMPL_BASIC_CONVERTER_IB(Long, long, long, c_long, PyLong_FromLong, CPyCppyy_PyLong_AsStrictLong, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(Long, long, long, c_long, 'l')
 
 //----------------------------------------------------------------------------
 bool CPyCppyy::LongRefConverter::SetArg(
@@ -828,17 +784,17 @@ bool CPyCppyy::LongRefConverter::SetArg(
 CPPYY_IMPL_BASIC_CONST_CHAR_REFCONVERTER(Char,  char,          c_char,  CHAR_MIN,  CHAR_MAX)
 CPPYY_IMPL_BASIC_CONST_CHAR_REFCONVERTER(UChar, unsigned char, c_uchar,        0, UCHAR_MAX)
 
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Bool,   bool,           c_bool,      CPyCppyy_PyLong_AsBool)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Int8,   int8_t,         c_int8,      CPyCppyy_PyLong_AsInt8)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UInt8,  uint8_t,        c_uint8,     CPyCppyy_PyLong_AsUInt8)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Short,  short,          c_short,     CPyCppyy_PyLong_AsShort)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UShort, unsigned short, c_ushort,    CPyCppyy_PyLong_AsUShort)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Int,    int,            c_int,       CPyCppyy_PyLong_AsStrictInt)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UInt,   unsigned int,   c_uint,      PyLongOrInt_AsULong)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Long,   long,           c_long,      CPyCppyy_PyLong_AsStrictLong)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(ULong,  unsigned long,  c_ulong,     PyLongOrInt_AsULong)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(LLong,  PY_LONG_LONG,   c_longlong,  CPyCppyy_PyLong_AsStrictLongLong)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(ULLong, PY_ULONG_LONG,  c_ulonglong, PyLongOrInt_AsULong64)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Bool, bool, c_bool)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Int8, int8_t, c_int8)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UInt8, uint8_t, c_uint8)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Short, short, c_short)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UShort, unsigned short, c_ushort)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Int, int, c_int)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(UInt, unsigned int, c_uint)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Long, long, c_long)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(ULong, unsigned long, c_ulong)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(LLong, PY_LONG_LONG, c_longlong)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(ULLong, PY_ULONG_LONG, c_ulonglong)
 
 //----------------------------------------------------------------------------
 bool CPyCppyy::IntRefConverter::SetArg(
@@ -921,8 +877,7 @@ CPPYY_IMPL_REFCONVERTER(LDouble, c_longdouble, PY_LONG_DOUBLE,     'g');
 
 //----------------------------------------------------------------------------
 // convert <pyobject> to C++ bool, allow int/long -> bool, set arg for call
-CPPYY_IMPL_BASIC_CONVERTER_NI(
-    Bool, bool, long, c_bool, PyBool_FromLong, CPyCppyy_PyLong_AsBool, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_NI(Bool, bool, long, c_bool, 'l')
 
 //----------------------------------------------------------------------------
 CPPYY_IMPL_BASIC_CHAR_CONVERTER(Char,  char,          CHAR_MIN,  CHAR_MAX)
@@ -1060,16 +1015,11 @@ bool CPyCppyy::Char32Converter::ToMemory(PyObject* value, void* address, PyObjec
 }
 
 //----------------------------------------------------------------------------
-CPPYY_IMPL_BASIC_CONVERTER_IB(
-    Int8,  int8_t,  long, c_int8, PyInt_FromLong, CPyCppyy_PyLong_AsInt8,  'l')
-CPPYY_IMPL_BASIC_CONVERTER_IB(
-    UInt8, uint8_t, long, c_uint8, PyInt_FromLong, CPyCppyy_PyLong_AsUInt8, 'l')
-CPPYY_IMPL_BASIC_CONVERTER_IB(
-    Short, short, long, c_short, PyInt_FromLong, CPyCppyy_PyLong_AsShort, 'l')
-CPPYY_IMPL_BASIC_CONVERTER_IB(
-    UShort, unsigned short, long, c_ushort, PyInt_FromLong, CPyCppyy_PyLong_AsUShort, 'l')
-CPPYY_IMPL_BASIC_CONVERTER_IB(
-    Int, int, long, c_uint, PyInt_FromLong, CPyCppyy_PyLong_AsStrictInt, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(Int8, int8_t, long, c_int8, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(UInt8, uint8_t, long, c_uint8, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(Short, short, long, c_short, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(UShort, unsigned short, long, c_ushort, 'l')
+CPPYY_IMPL_BASIC_CONVERTER_IB(Int, int, long, c_uint, 'l')
 
 //----------------------------------------------------------------------------
 bool CPyCppyy::ULongConverter::SetArg(
@@ -1131,13 +1081,10 @@ bool CPyCppyy::UIntConverter::ToMemory(PyObject* value, void* address, PyObject*
 }
 
 //- floating point converters ------------------------------------------------
-CPPYY_IMPL_BASIC_CONVERTER_NB(
-    Float,  float,  double, c_float,  PyFloat_FromDouble, PyFloat_AsDouble, 'f')
-CPPYY_IMPL_BASIC_CONVERTER_NB(
-    Double, double, double, c_double, PyFloat_FromDouble, PyFloat_AsDouble, 'd')
+CPPYY_IMPL_BASIC_CONVERTER_NB(Float, float, double, c_float, 'f')
+CPPYY_IMPL_BASIC_CONVERTER_NB(Double, double, double, c_double, 'd')
 
-CPPYY_IMPL_BASIC_CONVERTER_NB(
-    LDouble, PY_LONG_DOUBLE, PY_LONG_DOUBLE, c_longdouble, PyFloat_FromDouble, PyFloat_AsDouble, 'g')
+CPPYY_IMPL_BASIC_CONVERTER_NB(LDouble, PY_LONG_DOUBLE, PY_LONG_DOUBLE, c_longdouble, 'g')
 
 CPyCppyy::ComplexDConverter::ComplexDConverter(bool keepControl) :
     InstanceConverter(Cppyy::GetFullScope("std::complex<double>"), keepControl) {}
@@ -1213,9 +1160,9 @@ bool CPyCppyy::DoubleRefConverter::SetArg(
 }
 
 //----------------------------------------------------------------------------
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Float,   float,          c_float,      PyFloat_AsDouble)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Double,  double,         c_double,     PyFloat_AsDouble)
-CPPYY_IMPL_BASIC_CONST_REFCONVERTER(LDouble, PY_LONG_DOUBLE, c_longdouble, PyFloat_AsDouble)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Float, float, c_float)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(Double, double, c_double)
+CPPYY_IMPL_BASIC_CONST_REFCONVERTER(LDouble, PY_LONG_DOUBLE, c_longdouble)
 
 //----------------------------------------------------------------------------
 bool CPyCppyy::VoidConverter::SetArg(PyObject*, Parameter&, CallContext*)
@@ -1233,9 +1180,10 @@ bool CPyCppyy::LLongConverter::SetArg(
     if (!ImplicitBool(pyobject, ctxt))
         return false;
 
-    para.fValue.fLLong = CPyCppyy_PyLong_AsStrictLongLong(pyobject);
-    if (PyErr_Occurred())
+    PY_LONG_LONG val;
+    if (!MarshalFromPyStrict<PY_LONG_LONG>(pyobject, val))
         return false;
+    para.fValue.fLLong = val;
     para.fTypeCode = 'q';
     return true;
 }

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -29,6 +29,9 @@
 #include <sstream>
 #include <cstddef>
 #include <string_view>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -55,6 +58,14 @@ namespace CPyCppyy {
 // factories
     typedef std::map<std::string, cf_t> ConvFactories_t;
     static ConvFactories_t gConvFactories;
+
+// Canonical TCppType_t -> cf_t projection of gConvFactories. Built
+// lazily and dropped whenever the public Register*/UnregisterConverter
+// API mutates the source so the cache cannot go stale.
+    typedef std::unordered_map<Cppyy::TCppType_t, cf_t> ConvFactoriesByType_t;
+    static ConvFactoriesByType_t gConvFactoriesByType;
+    static std::mutex gConvFactoriesByTypeMutex;
+    static bool gConvFactoriesByTypePopulated = false;
 
 // special objects
     extern PyObject* gNullPtrObject;
@@ -3537,6 +3548,46 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
 CPYCPPYY_EXPORT
 CPyCppyy::Converter* CPyCppyy::CreateConverter(Cppyy::TCppType_t type, cdims_t dims)
 {
+// Canonical-identity primary lookup. The string ladder below stays as
+// the fallback for decoration-policy cases (drop const, array decay,
+// T&& -> const T&) that aren't yet expressible as QT transforms.
+//
+// Lock covers population and lookup so a concurrent
+// Register*/UnregisterConverter can't catch the cache mid-rebuild.
+// Alias-collision skip: two spellings, same TCppType_t, different
+// cf_t -- can't choose one, so leave the pair on the string path.
+    cf_t qt_fac = nullptr;
+    {
+        std::lock_guard<std::mutex> _L(gConvFactoriesByTypeMutex);
+        if (!gConvFactoriesByTypePopulated) {
+            std::unordered_map<Cppyy::TCppType_t, cf_t> first_seen;
+            std::unordered_set<Cppyy::TCppType_t> ambiguous;
+            for (const auto& kv : gConvFactories) {
+                Cppyy::TCppType_t qt = nullptr;
+                try {
+                    qt = Cppyy::GetType(kv.first, /*enable_slow_lookup=*/true);
+                } catch (const std::exception&) {
+                    continue;  // pseudo-type spelling (e.g. SCharAsInt).
+                }
+                if (!qt) continue;
+                auto it = first_seen.find(qt);
+                if (it == first_seen.end())
+                    first_seen.emplace(qt, kv.second);
+                else if (it->second != kv.second)
+                    ambiguous.insert(qt);
+            }
+            for (const auto& kv : first_seen)
+                if (!ambiguous.count(kv.first))
+                    gConvFactoriesByType.emplace(kv.first, kv.second);
+            gConvFactoriesByTypePopulated = true;
+        }
+        auto h = gConvFactoriesByType.find(type);
+        if (h != gConvFactoriesByType.end())
+            qt_fac = h->second;
+    }
+    if (qt_fac)
+        return qt_fac(dims);
+
 // The matching of the fulltype to a converter factory goes through up to five levels:
 //   1) full, exact match
 //   2) match of decorated, unqualified type
@@ -3759,6 +3810,15 @@ void CPyCppyy::DestroyConverter(Converter* p)
 }
 
 //----------------------------------------------------------------------------
+namespace CPyCppyy {
+// Drop the QT projection so CreateConverter rebuilds it on next call.
+static void InvalidateConvFactoriesByType() {
+    std::lock_guard<std::mutex> _L(gConvFactoriesByTypeMutex);
+    gConvFactoriesByType.clear();
+    gConvFactoriesByTypePopulated = false;
+}
+} // namespace CPyCppyy
+
 CPYCPPYY_EXPORT
 bool CPyCppyy::RegisterConverter(const std::string& name, cf_t fac)
 {
@@ -3768,6 +3828,7 @@ bool CPyCppyy::RegisterConverter(const std::string& name, cf_t fac)
         return false;
 
     gConvFactories[name] = fac;
+    InvalidateConvFactoriesByType();
     return true;
 }
 
@@ -3785,6 +3846,7 @@ bool CPyCppyy::RegisterConverterAlias(const std::string& name, const std::string
         return false;
 
     gConvFactories[name] = t->second;
+    InvalidateConvFactoriesByType();
     return true;
 }
 
@@ -3796,6 +3858,7 @@ bool CPyCppyy::UnregisterConverter(const std::string& name)
     auto f = gConvFactories.find(name);
     if (f != gConvFactories.end()) {
         gConvFactories.erase(f);
+        InvalidateConvFactoriesByType();
         return true;
     }
     return false;

--- a/src/DeclareExecutors.h
+++ b/src/DeclareExecutors.h
@@ -22,7 +22,6 @@ public:                                                                      \
 }
 
 // executors for built-ins
-CPPYY_DECL_EXEC(Bool);
 CPPYY_DECL_EXEC(BoolConstRef);
 CPPYY_DECL_EXEC(Char);
 CPPYY_DECL_EXEC(CharConstRef);
@@ -31,17 +30,6 @@ CPPYY_DECL_EXEC(UCharConstRef);
 CPPYY_DECL_EXEC(WChar);
 CPPYY_DECL_EXEC(Char16);
 CPPYY_DECL_EXEC(Char32);
-CPPYY_DECL_EXEC(Int8);
-CPPYY_DECL_EXEC(UInt8);
-CPPYY_DECL_EXEC(Short);
-CPPYY_DECL_EXEC(Int);
-CPPYY_DECL_EXEC(Long);
-CPPYY_DECL_EXEC(ULong);
-CPPYY_DECL_EXEC(LongLong);
-CPPYY_DECL_EXEC(ULongLong);
-CPPYY_DECL_EXEC(Float);
-CPPYY_DECL_EXEC(Double);
-CPPYY_DECL_EXEC(LongDouble);
 CPPYY_DECL_EXEC(Void);
 CPPYY_DECL_EXEC(CString);
 CPPYY_DECL_EXEC(CStringRef);

--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -8,6 +8,7 @@
 #include "PyStrings.h"
 #include "TypeManip.h"
 #include "Utility.h"
+#include "MarshalScalar.h"
 
 // Standard
 #include <cstring>
@@ -78,6 +79,43 @@ CPPYY_IMPL_GILCALL(double,         D)
 CPPYY_IMPL_GILCALL(PY_LONG_DOUBLE, LD)
 CPPYY_IMPL_GILCALL(void*,          R)
 
+// Compile-time map T -> GILCall<X>: one entry to update when a new
+// fundamental T joins the family. ScalarExecutor<T> below dispatches
+// through it.
+namespace {
+
+template <class T> T GILCallFor(Cppyy::TCppMethod_t, Cppyy::TCppObject_t,
+                                CPyCppyy::CallContext*);
+
+template <> inline bool      GILCallFor<bool>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallB(m, s, c); }
+template <> inline int8_t    GILCallFor<int8_t>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (int8_t)GILCallC(m, s, c); }
+template <> inline uint8_t   GILCallFor<uint8_t>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (uint8_t)GILCallB(m, s, c); }
+template <> inline short     GILCallFor<short>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallH(m, s, c); }
+template <> inline unsigned short GILCallFor<unsigned short>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (unsigned short)GILCallI(m, s, c); }
+template <> inline int       GILCallFor<int>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallI(m, s, c); }
+template <> inline unsigned int GILCallFor<unsigned int>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (unsigned int)GILCallL(m, s, c); }
+template <> inline long      GILCallFor<long>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallL(m, s, c); }
+template <> inline unsigned long GILCallFor<unsigned long>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (unsigned long)GILCallLL(m, s, c); }
+template <> inline PY_LONG_LONG  GILCallFor<PY_LONG_LONG>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallLL(m, s, c); }
+template <> inline PY_ULONG_LONG GILCallFor<PY_ULONG_LONG>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return (PY_ULONG_LONG)GILCallLL(m, s, c); }
+template <> inline float     GILCallFor<float>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallF(m, s, c); }
+template <> inline double    GILCallFor<double>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallD(m, s, c); }
+template <> inline PY_LONG_DOUBLE GILCallFor<PY_LONG_DOUBLE>(Cppyy::TCppMethod_t m, Cppyy::TCppObject_t s, CPyCppyy::CallContext* c) { return GILCallLD(m, s, c); }
+
+// Single Execute body for every fundamental scalar T: call into C++
+// through GILCallFor<T>, hand the result to MarshalScalar.h.
+template <class T>
+class ScalarExecutor : public CPyCppyy::Executor {
+public:
+    PyObject* Execute(Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self,
+                      CPyCppyy::CallContext* ctxt) override {
+        T result = GILCallFor<T>(method, self, ctxt);
+        return CPyCppyy::MarshalToPy<T>(result);
+    }
+};
+
+} // anonymous namespace
+
 static inline Cppyy::TCppObject_t GILCallO(Cppyy::TCppMethod_t method,
     Cppyy::TCppObject_t self, CPyCppyy::CallContext* ctxt, Cppyy::TCppScope_t klass)
 {
@@ -143,16 +181,6 @@ CPyCppyy::Executor::~Executor()
 }
 
 //- executors for built-ins --------------------------------------------------
-PyObject* CPyCppyy::BoolExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python bool return value
-    bool retval = GILCallB(method, self, ctxt);
-    PyObject* result = retval ? Py_True : Py_False;
-    Py_INCREF(result);
-    return result;
-}
-
 //----------------------------------------------------------------------------
 PyObject* CPyCppyy::BoolConstRefExecutor::Execute(
     Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
@@ -225,96 +253,6 @@ PyObject* CPyCppyy::Char32Executor::Execute(
 // with the single char32
     char32_t res = (char32_t)GILCallL(method, self, ctxt);
     return PyUnicode_DecodeUTF32((const char*)&res, sizeof(char32_t), nullptr, nullptr);
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::IntExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python int return value
-    return PyInt_FromLong((int)GILCallI(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::Int8Executor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python int return value
-    return PyInt_FromLong((int8_t)GILCallC(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::UInt8Executor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python int return value
-    return PyInt_FromLong((uint8_t)GILCallB(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::ShortExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python int return value
-    return PyInt_FromLong((short)GILCallH(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::LongExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python long return value
-    return PyLong_FromLong((long)GILCallL(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::ULongExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python unsigned long return value
-    return PyLong_FromUnsignedLong((unsigned long)GILCallLL(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::LongLongExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python long long return value
-    PY_LONG_LONG result = GILCallLL(method, self, ctxt);
-    return PyLong_FromLongLong(result);
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::ULongLongExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python unsigned long long return value
-    PY_ULONG_LONG result = (PY_ULONG_LONG)GILCallLL(method, self, ctxt);
-    return PyLong_FromUnsignedLongLong(result);
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::FloatExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python float return value
-    return PyFloat_FromDouble((double)GILCallF(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::DoubleExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python float return value
-    return PyFloat_FromDouble((double)GILCallD(method, self, ctxt));
-}
-
-//----------------------------------------------------------------------------
-PyObject* CPyCppyy::LongDoubleExecutor::Execute(
-    Cppyy::TCppMethod_t method, Cppyy::TCppObject_t self, CallContext* ctxt)
-{
-// execute <method> with argument <self, ctxt>, construct python float return value
-    return PyFloat_FromDouble((double)GILCallLD(method, self, ctxt));
 }
 
 //----------------------------------------------------------------------------
@@ -1103,7 +1041,7 @@ public:
         CPyCppyy::ExecFactories_t& gf = gExecFactories;
 
     // factories for built-ins
-        gf["bool"] =                        (ef_t)+[](cdims_t) { static BoolExecutor e{};          return &e; };
+        gf["bool"] =                        (ef_t)+[](cdims_t) { static ScalarExecutor<bool> e{};          return &e; };
         gf["bool&"] =                       (ef_t)+[](cdims_t) { return new BoolRefExecutor{}; };
         gf["const bool&"] =                 (ef_t)+[](cdims_t) { static BoolConstRefExecutor e{};  return &e; };
         gf["char"] =                        (ef_t)+[](cdims_t) { static CharExecutor e{};          return &e; };
@@ -1118,36 +1056,36 @@ public:
         gf["wchar_t"] =                     (ef_t)+[](cdims_t) { static WCharExecutor e{};         return &e; };
         gf["char16_t"] =                    (ef_t)+[](cdims_t) { static Char16Executor e{};        return &e; };
         gf["char32_t"] =                    (ef_t)+[](cdims_t) { static Char32Executor e{};        return &e; };
-        gf["int8_t"] =                      (ef_t)+[](cdims_t) { static Int8Executor e{};          return &e; };
+        gf["int8_t"] =                      (ef_t)+[](cdims_t) { static ScalarExecutor<int8_t> e{};          return &e; };
         gf["int8_t&"] =                     (ef_t)+[](cdims_t) { return new Int8RefExecutor{}; };
         gf["const int8_t&"] =               (ef_t)+[](cdims_t) { static Int8RefExecutor e{};       return &e; };
-        gf["uint8_t"] =                     (ef_t)+[](cdims_t) { static UInt8Executor e{};         return &e; };
+        gf["uint8_t"] =                     (ef_t)+[](cdims_t) { static ScalarExecutor<uint8_t> e{};         return &e; };
         gf["uint8_t&"] =                    (ef_t)+[](cdims_t) { return new UInt8RefExecutor{}; };
         gf["const uint8_t&"] =              (ef_t)+[](cdims_t) { static UInt8RefExecutor e{};      return &e; };
-        gf["short"] =                       (ef_t)+[](cdims_t) { static ShortExecutor e{};         return &e; };
+        gf["short"] =                       (ef_t)+[](cdims_t) { static ScalarExecutor<short> e{};         return &e; };
         gf["short&"] =                      (ef_t)+[](cdims_t) { return new ShortRefExecutor{}; };
-        gf["int"] =                         (ef_t)+[](cdims_t) { static IntExecutor e{};           return &e; };
+        gf["int"] =                         (ef_t)+[](cdims_t) { static ScalarExecutor<int> e{};           return &e; };
         gf["int&"] =                        (ef_t)+[](cdims_t) { return new IntRefExecutor{}; };
         gf["unsigned short"] =              gf["int"];
         gf["unsigned short&"] =             (ef_t)+[](cdims_t) { return new UShortRefExecutor{}; };
-        gf["unsigned long"] =               (ef_t)+[](cdims_t) { static ULongExecutor e{};         return &e; };
+        gf["unsigned long"] =               (ef_t)+[](cdims_t) { static ScalarExecutor<unsigned long> e{};         return &e; };
         gf["unsigned long&"] =              (ef_t)+[](cdims_t) { return new ULongRefExecutor{}; };
         gf["unsigned int"] =                gf["unsigned long"];
         gf["unsigned int&"] =               (ef_t)+[](cdims_t) { return new UIntRefExecutor{}; };
-        gf["long"] =                        (ef_t)+[](cdims_t) { static LongExecutor e{};          return &e; };
+        gf["long"] =                        (ef_t)+[](cdims_t) { static ScalarExecutor<long> e{};          return &e; };
         gf["long&"] =                       (ef_t)+[](cdims_t) { return new LongRefExecutor{}; };
-        gf["unsigned long"] =               (ef_t)+[](cdims_t) { static ULongExecutor e{};         return &e; };
+        gf["unsigned long"] =               (ef_t)+[](cdims_t) { static ScalarExecutor<unsigned long> e{};         return &e; };
         gf["unsigned long&"] =              (ef_t)+[](cdims_t) { return new ULongRefExecutor{}; };
-        gf["long long"] =                   (ef_t)+[](cdims_t) { static LongLongExecutor e{};      return &e; };
+        gf["long long"] =                   (ef_t)+[](cdims_t) { static ScalarExecutor<PY_LONG_LONG> e{};      return &e; };
         gf["long long&"] =                  (ef_t)+[](cdims_t) { return new LongLongRefExecutor{}; };
-        gf["unsigned long long"] =          (ef_t)+[](cdims_t) { static ULongLongExecutor e{};     return &e; };
+        gf["unsigned long long"] =          (ef_t)+[](cdims_t) { static ScalarExecutor<PY_ULONG_LONG> e{};     return &e; };
         gf["unsigned long long&"] =         (ef_t)+[](cdims_t) { return new ULongLongRefExecutor{}; };
 
-        gf["float"] =                       (ef_t)+[](cdims_t) { static FloatExecutor e{};      return &e; };
+        gf["float"] =                       (ef_t)+[](cdims_t) { static ScalarExecutor<float> e{};      return &e; };
         gf["float&"] =                      (ef_t)+[](cdims_t) { return new FloatRefExecutor{}; };
-        gf["double"] =                      (ef_t)+[](cdims_t) { static DoubleExecutor e{};     return &e; };
+        gf["double"] =                      (ef_t)+[](cdims_t) { static ScalarExecutor<double> e{};     return &e; };
         gf["double&"] =                     (ef_t)+[](cdims_t) { return new DoubleRefExecutor{}; };
-        gf["long double"] =                 (ef_t)+[](cdims_t) { static LongDoubleExecutor e{}; return &e; }; // TODO: lost precision
+        gf["long double"] =                 (ef_t)+[](cdims_t) { static ScalarExecutor<PY_LONG_DOUBLE> e{}; return &e; }; // TODO: lost precision
         gf["long double&"] =                (ef_t)+[](cdims_t) { return new LongDoubleRefExecutor{}; };
         gf["std::complex<double>"] =        (ef_t)+[](cdims_t) { static ComplexDExecutor e{};    return &e; };
         gf["std::complex<double>&"] =       (ef_t)+[](cdims_t) { return new ComplexDRefExecutor{}; };

--- a/src/MarshalScalar.h
+++ b/src/MarshalScalar.h
@@ -1,0 +1,354 @@
+#ifndef CPYCPPYY_MARSHALSCALAR_H
+#define CPYCPPYY_MARSHALSCALAR_H
+
+// Single source of truth for scalar marshaling between Python and C++.
+// Each specialization signals failure via Python's C-API convention
+// (NULL / -1 + PyErr_Occurred) -- never a C++ throw -- so the contract
+// is noexcept and callers can strip exception-handling plumbing.
+
+#include "Cppyy.h"  // for PY_LONG_DOUBLE
+#include <Python.h>
+#include <climits>
+#include <cstdint>
+
+namespace CPyCppyy { extern PyObject* gDefaultObject; }
+
+namespace CPyCppyy {
+
+// Primary templates deliberately undefined: an unsupported T at a
+// callsite fails to link with a recognizable symbol name. The Strict
+// variant matches the slow-path SetArg/ToMemory policy (range-checked,
+// rejects float-to-int coercion); the non-Strict pair is for callsites
+// that have already validated.
+template <class T> PyObject* MarshalToPy(const T& v) noexcept;
+template <class T> bool      MarshalFromPy(PyObject* o, T& out) noexcept;
+template <class T> bool      MarshalFromPyStrict(PyObject* o, T& out) noexcept;
+
+// --- bool ------------------------------------------------------------------
+template <> inline PyObject* MarshalToPy<bool>(const bool& v) noexcept {
+  return PyBool_FromLong(v);
+}
+template <> inline bool MarshalFromPy<bool>(PyObject* o, bool& out) noexcept {
+  int r = PyObject_IsTrue(o);
+  if (r < 0) return false;
+  out = (r != 0);
+  return true;
+}
+
+// --- int8 / uint8 ----------------------------------------------------------
+template <> inline PyObject* MarshalToPy<int8_t>(const int8_t& v) noexcept {
+  return PyLong_FromLong(v);
+}
+template <> inline bool MarshalFromPy<int8_t>(PyObject* o,
+                                              int8_t& out) noexcept {
+  long v = PyLong_AsLong(o);
+  if (v == -1 && PyErr_Occurred()) return false;
+  out = static_cast<int8_t>(v);
+  return true;
+}
+
+template <> inline PyObject* MarshalToPy<uint8_t>(const uint8_t& v) noexcept {
+  return PyLong_FromLong(v);
+}
+template <> inline bool MarshalFromPy<uint8_t>(PyObject* o,
+                                               uint8_t& out) noexcept {
+  unsigned long v = PyLong_AsUnsignedLong(o);
+  if (v == static_cast<unsigned long>(-1) && PyErr_Occurred()) return false;
+  out = static_cast<uint8_t>(v);
+  return true;
+}
+
+// --- short family ----------------------------------------------------------
+template <> inline PyObject* MarshalToPy<short>(const short& v) noexcept {
+  return PyLong_FromLong(v);
+}
+template <> inline bool MarshalFromPy<short>(PyObject* o,
+                                             short& out) noexcept {
+  long v = PyLong_AsLong(o);
+  if (v == -1 && PyErr_Occurred()) return false;
+  out = static_cast<short>(v);
+  return true;
+}
+
+template <> inline PyObject*
+MarshalToPy<unsigned short>(const unsigned short& v) noexcept {
+  return PyLong_FromUnsignedLong(v);
+}
+template <> inline bool MarshalFromPy<unsigned short>(
+    PyObject* o, unsigned short& out) noexcept {
+  unsigned long v = PyLong_AsUnsignedLong(o);
+  if (v == static_cast<unsigned long>(-1) && PyErr_Occurred()) return false;
+  out = static_cast<unsigned short>(v);
+  return true;
+}
+
+// --- int / unsigned int ----------------------------------------------------
+template <> inline PyObject* MarshalToPy<int>(const int& v) noexcept {
+  return PyLong_FromLong(v);
+}
+template <> inline bool MarshalFromPy<int>(PyObject* o, int& out) noexcept {
+  long v = PyLong_AsLong(o);
+  if (v == -1 && PyErr_Occurred()) return false;
+  out = static_cast<int>(v);
+  return true;
+}
+
+template <>
+inline PyObject* MarshalToPy<unsigned int>(const unsigned int& v) noexcept {
+  return PyLong_FromUnsignedLong(v);
+}
+template <> inline bool MarshalFromPy<unsigned int>(
+    PyObject* o, unsigned int& out) noexcept {
+  unsigned long v = PyLong_AsUnsignedLong(o);
+  if (v == static_cast<unsigned long>(-1) && PyErr_Occurred()) return false;
+  out = static_cast<unsigned int>(v);
+  return true;
+}
+
+// --- long / unsigned long --------------------------------------------------
+template <> inline PyObject* MarshalToPy<long>(const long& v) noexcept {
+  return PyLong_FromLong(v);
+}
+template <> inline bool MarshalFromPy<long>(PyObject* o, long& out) noexcept {
+  long v = PyLong_AsLong(o);
+  if (v == -1 && PyErr_Occurred()) return false;
+  out = v;
+  return true;
+}
+
+template <>
+inline PyObject* MarshalToPy<unsigned long>(const unsigned long& v) noexcept {
+  return PyLong_FromUnsignedLong(v);
+}
+template <> inline bool MarshalFromPy<unsigned long>(
+    PyObject* o, unsigned long& out) noexcept {
+  unsigned long v = PyLong_AsUnsignedLong(o);
+  if (v == static_cast<unsigned long>(-1) && PyErr_Occurred()) return false;
+  out = v;
+  return true;
+}
+
+// --- long long / unsigned long long ---------------------------------------
+template <>
+inline PyObject* MarshalToPy<long long>(const long long& v) noexcept {
+  return PyLong_FromLongLong(v);
+}
+template <> inline bool MarshalFromPy<long long>(PyObject* o,
+                                                 long long& out) noexcept {
+  long long v = PyLong_AsLongLong(o);
+  if (v == -1 && PyErr_Occurred()) return false;
+  out = v;
+  return true;
+}
+
+template <> inline PyObject*
+MarshalToPy<unsigned long long>(const unsigned long long& v) noexcept {
+  return PyLong_FromUnsignedLongLong(v);
+}
+template <> inline bool MarshalFromPy<unsigned long long>(
+    PyObject* o, unsigned long long& out) noexcept {
+  unsigned long long v = PyLong_AsUnsignedLongLong(o);
+  if (v == static_cast<unsigned long long>(-1) && PyErr_Occurred())
+    return false;
+  out = v;
+  return true;
+}
+
+// --- floating-point family -------------------------------------------------
+// PyFloat_AsDouble also accepts PyLong via __float__, matching Python's
+// numeric tower; the fast path leans on that rather than reject int returns.
+template <> inline PyObject* MarshalToPy<float>(const float& v) noexcept {
+  return PyFloat_FromDouble(v);
+}
+template <> inline bool MarshalFromPy<float>(PyObject* o,
+                                             float& out) noexcept {
+  double v = PyFloat_AsDouble(o);
+  if (v == -1.0 && PyErr_Occurred()) return false;
+  out = static_cast<float>(v);
+  return true;
+}
+
+template <> inline PyObject* MarshalToPy<double>(const double& v) noexcept {
+  return PyFloat_FromDouble(v);
+}
+template <> inline bool MarshalFromPy<double>(PyObject* o,
+                                              double& out) noexcept {
+  double v = PyFloat_AsDouble(o);
+  if (v == -1.0 && PyErr_Occurred()) return false;
+  out = v;
+  return true;
+}
+
+// PY_LONG_DOUBLE is typedef'd to long double in Cppyy.h.
+template <> inline PyObject*
+MarshalToPy<PY_LONG_DOUBLE>(const PY_LONG_DOUBLE& v) noexcept {
+  return PyFloat_FromDouble(static_cast<double>(v));
+}
+template <> inline bool MarshalFromPy<PY_LONG_DOUBLE>(
+    PyObject* o, PY_LONG_DOUBLE& out) noexcept {
+  double v = PyFloat_AsDouble(o);
+  if (v == -1.0 && PyErr_Occurred()) return false;
+  out = static_cast<PY_LONG_DOUBLE>(v);
+  return true;
+}
+
+
+// --- MarshalFromPyStrict specializations -----------------------------------
+// gDefaultObject is cppyy's "use the default" sentinel; silently coerce
+// to zero rather than raise (matches the legacy PyLong_As* validators).
+
+namespace detail {
+template <class T>
+inline bool ToIntStrict(PyObject* o, T& out, long lo, long hi) noexcept {
+    if (!PyLong_Check(o)) {
+        if (o == CPyCppyy::gDefaultObject) { out = (T)0; return true; }
+        PyErr_SetString(PyExc_TypeError,
+                        "integer object expected for marshaling");
+        return false;
+    }
+    long l = PyLong_AsLong(o);
+    if (l == -1 && PyErr_Occurred()) return false;
+    if (l < lo || hi < l) {
+        PyErr_Format(PyExc_ValueError,
+                     "integer %ld out of destination range", l);
+        return false;
+    }
+    out = static_cast<T>(l);
+    return true;
+}
+} // namespace detail
+
+template <> inline bool
+MarshalFromPyStrict<bool>(PyObject* o, bool& out) noexcept {
+    long l = PyLong_AsLong(o);
+    if (l == -1 && PyErr_Occurred()) return false;
+    if ((l != 0 && l != 1) || PyFloat_Check(o)) {
+        PyErr_SetString(PyExc_ValueError,
+                        "boolean value should be bool, or integer 1 or 0");
+        return false;
+    }
+    out = (l != 0);
+    return true;
+}
+
+template <> inline bool
+MarshalFromPyStrict<int8_t>(PyObject* o, int8_t& out) noexcept {
+    return detail::ToIntStrict(o, out, SCHAR_MIN, SCHAR_MAX);
+}
+template <> inline bool
+MarshalFromPyStrict<uint8_t>(PyObject* o, uint8_t& out) noexcept {
+    return detail::ToIntStrict(o, out, 0, UCHAR_MAX);
+}
+template <> inline bool
+MarshalFromPyStrict<short>(PyObject* o, short& out) noexcept {
+    return detail::ToIntStrict(o, out, SHRT_MIN, SHRT_MAX);
+}
+template <> inline bool
+MarshalFromPyStrict<unsigned short>(PyObject* o,
+                                    unsigned short& out) noexcept {
+    return detail::ToIntStrict(o, out, 0, USHRT_MAX);
+}
+template <> inline bool
+MarshalFromPyStrict<int>(PyObject* o, int& out) noexcept {
+    return detail::ToIntStrict(o, out, INT_MIN, INT_MAX);
+}
+template <> inline bool
+MarshalFromPyStrict<unsigned int>(PyObject* o,
+                                  unsigned int& out) noexcept {
+    return detail::ToIntStrict(o, out, 0, UINT_MAX);
+}
+
+template <> inline bool
+MarshalFromPyStrict<long>(PyObject* o, long& out) noexcept {
+    if (!PyLong_Check(o)) {
+        if (o == CPyCppyy::gDefaultObject) { out = 0; return true; }
+        PyErr_SetString(PyExc_TypeError,
+                        "integer object expected for marshaling");
+        return false;
+    }
+    long l = PyLong_AsLong(o);
+    if (l == -1 && PyErr_Occurred()) return false;
+    out = l;
+    return true;
+}
+template <> inline bool
+MarshalFromPyStrict<unsigned long>(PyObject* o,
+                                   unsigned long& out) noexcept {
+    if (!PyLong_Check(o)) {
+        if (o == CPyCppyy::gDefaultObject) { out = 0; return true; }
+        PyErr_SetString(PyExc_TypeError,
+                        "integer object expected for marshaling");
+        return false;
+    }
+    unsigned long v = PyLong_AsUnsignedLong(o);
+    if (v == (unsigned long)-1 && PyErr_Occurred()) return false;
+    out = v;
+    return true;
+}
+
+template <> inline bool
+MarshalFromPyStrict<long long>(PyObject* o, long long& out) noexcept {
+    if (!PyLong_Check(o)) {
+        if (o == CPyCppyy::gDefaultObject) { out = 0; return true; }
+        PyErr_SetString(PyExc_TypeError,
+                        "integer object expected for marshaling");
+        return false;
+    }
+    long long v = PyLong_AsLongLong(o);
+    if (v == -1 && PyErr_Occurred()) return false;
+    out = v;
+    return true;
+}
+template <> inline bool
+MarshalFromPyStrict<unsigned long long>(PyObject* o,
+                                        unsigned long long& out) noexcept {
+    if (!PyLong_Check(o)) {
+        if (o == CPyCppyy::gDefaultObject) { out = 0; return true; }
+        PyErr_SetString(PyExc_TypeError,
+                        "integer object expected for marshaling");
+        return false;
+    }
+    unsigned long long v = PyLong_AsUnsignedLongLong(o);
+    if (v == (unsigned long long)-1 && PyErr_Occurred()) return false;
+    out = v;
+    return true;
+}
+
+// Float family: Python's PyFloat_AsDouble already accepts numeric tower
+// (PyLong via __float__); strict() matches PyFloat_AsDouble behavior --
+// no extra rejection.
+template <> inline bool
+MarshalFromPyStrict<float>(PyObject* o, float& out) noexcept {
+    double v = PyFloat_AsDouble(o);
+    if (v == -1.0 && PyErr_Occurred()) {
+        if (o == CPyCppyy::gDefaultObject) { PyErr_Clear(); out = 0; return true; }
+        return false;
+    }
+    out = static_cast<float>(v);
+    return true;
+}
+template <> inline bool
+MarshalFromPyStrict<double>(PyObject* o, double& out) noexcept {
+    double v = PyFloat_AsDouble(o);
+    if (v == -1.0 && PyErr_Occurred()) {
+        if (o == CPyCppyy::gDefaultObject) { PyErr_Clear(); out = 0; return true; }
+        return false;
+    }
+    out = v;
+    return true;
+}
+template <> inline bool
+MarshalFromPyStrict<PY_LONG_DOUBLE>(PyObject* o,
+                                    PY_LONG_DOUBLE& out) noexcept {
+    double v = PyFloat_AsDouble(o);
+    if (v == -1.0 && PyErr_Occurred()) {
+        if (o == CPyCppyy::gDefaultObject) { PyErr_Clear(); out = 0; return true; }
+        return false;
+    }
+    out = static_cast<PY_LONG_DOUBLE>(v);
+    return true;
+}
+
+} // namespace CPyCppyy
+
+#endif // CPYCPPYY_MARSHALSCALAR_H


### PR DESCRIPTION
Each per-T Python C-API conversion (PyLong_FromLong, PyFloat_AsDouble, PyObject_IsTrue, ...) was open-coded in two parallel places: the CPPYY_IMPL_BASIC_CONVERTER macro family in Converters.cxx and the per-T Executor subclasses in Executors.cxx. Adding a new scalar meant editing both sides; the two paths drifted, and the range-check / float-reject policy lived only in macro-passed validators that the executor side didn't share.

Introduce MarshalScalar.h: header-only MarshalToPy<T> and MarshalFromPy<T>, plus a Strict variant matching the slow-path SetArg/ToMemory contract (range-checked, rejects float-to-int, coerces the gDefaultObject sentinel to zero). Converters and executors both delegate through it; failure flows through Python's C-API convention (NULL / -1 + PyErr_Occurred) so callers stay noexcept.

The macro-time F1 / F2 validator arguments drop out of the Converter family entirely, and the twelve per-T scalar Executor subclasses collapse into a single ScalarExecutor<T> template.

Depends on #203.