### PR TITLE
Fix StdSpanConverter ctor param type for strong typing

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -1666,7 +1666,7 @@ namespace CPyCppyy {
 
 class StdSpanConverter : public InstanceConverter {
 public:
-    StdSpanConverter(std::string const &typeName, Cppyy::TCppType_t klass, bool keepControl = false)
+    StdSpanConverter(std::string const &typeName, Cppyy::TCppScope_t klass, bool keepControl = false)
         : InstanceConverter{klass, keepControl}, fTypeName{typeName}
     {
     }


### PR DESCRIPTION
`StdSpanConverter`'s ctor takes `TCppType_t klass` but forwards it to `InstanceConverter(TCppScope_t)`, and the call site passes `GetScope()`. Align the parameter type.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)