### PR TITLE
Fix __contains__ registration under newer C++ standards

### DIFF
--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -1254,7 +1254,6 @@ PyObject* STLStringDecode(CPPInstance* self, PyObject* args, PyObject* kwds)
     return PyUnicode_Decode(obj->data(), obj->size(), encoding, errors);
 }
 
-#if __cplusplus <= 202302L
 PyObject* STLStringContains(CPPInstance* self, PyObject* pyobj)
 {
     std::string* obj = GetSTLString(self);
@@ -1271,7 +1270,6 @@ PyObject* STLStringContains(CPPInstance* self, PyObject* pyobj)
 
     Py_RETURN_FALSE;
 }
-#endif
 
 PyObject* STLStringReplace(CPPInstance* self, PyObject* args, PyObject* /*kwds*/)
 {
@@ -1923,10 +1921,11 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
         Utility::AddToClass(pyclass, "__cmp__",       (PyCFunction)STLStringCompare,    METH_O);
         Utility::AddToClass(pyclass, "__eq__",        (PyCFunction)STLStringIsEqual,    METH_O);
         Utility::AddToClass(pyclass, "__ne__",        (PyCFunction)STLStringIsNotEqual, METH_O);
-#if __cplusplus <= 202302L
-    // From C++23, std::string already implements a contains() method.
+    // Python's `in` operator needs __contains__ on the proxy regardless of the
+    // C++ standard CPyCppyy is built with; it never dispatches to C++'s
+    // std::string::contains (C++23+). The old `__cplusplus <= 202302L` guard
+    // wrongly dropped it when built with -std=c++2c (__cplusplus == 202400L).
         Utility::AddToClass(pyclass, "__contains__",  (PyCFunction)STLStringContains,   METH_O);
-#endif
         Utility::AddToClass(pyclass, "decode",        (PyCFunction)STLStringDecode,     METH_VARARGS | METH_KEYWORDS);
         Utility::AddToClass(pyclass, "__cpp_find",    "find");
         Utility::AddToClass(pyclass, "find",          (PyCFunction)STLStringFind,       METH_VARARGS | METH_KEYWORDS);

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -884,7 +884,6 @@ PyObject* MapInit(PyObject* self, PyObject* args, PyObject* /* kwds */)
     return nullptr;
 }
 
-#if __cplusplus <= 202002L
 PyObject* STLContainsWithFind(PyObject* self, PyObject* obj)
 {
 // Implement python's __contains__ for std::map/std::set
@@ -911,7 +910,6 @@ PyObject* STLContainsWithFind(PyObject* self, PyObject* obj)
 
     return result;
 }
-#endif
 
 
 //- set behavior as primitives ------------------------------------------------
@@ -1878,20 +1876,24 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
     // constructor that takes python associative collections
         Utility::AddToClass(pyclass, "__real_init", "__init__");
         Utility::AddToClass(pyclass, "__init__", (PyCFunction)MapInit, METH_VARARGS | METH_KEYWORDS);
-#if __cplusplus <= 202002L
-    // From C++20, std::map and std::unordered_map already implement a contains() method.
-        Utility::AddToClass(pyclass, "__contains__", (PyCFunction)STLContainsWithFind, METH_O);
-#endif
+    // From C++20, std::map/unordered_map have a native contains() that the generic
+    // contains->__contains__ mapping above will pick up. Strong-types reflection
+    // does not always expose it, so fall back to a find()-based __contains__ when
+    // none was reflected (still O(log n)/O(1), never iterating).
+        if (!HasAttrDirect(pyclass, PyStrings::gContains))
+            Utility::AddToClass(pyclass, "__contains__", (PyCFunction)STLContainsWithFind, METH_O);
     }
 
     else if (IsTemplatedSTLClass(name, "set")) {
     // constructor that takes python associative collections
         Utility::AddToClass(pyclass, "__real_init", "__init__");
         Utility::AddToClass(pyclass, "__init__", (PyCFunction)SetInit, METH_VARARGS | METH_KEYWORDS);
-#if __cplusplus <= 202002L
-    // From C++20, std::set already implements a contains() method.
-        Utility::AddToClass(pyclass, "__contains__", (PyCFunction)STLContainsWithFind, METH_O);
-#endif
+    // From C++20, std::set has a native contains() that the generic
+    // contains->__contains__ mapping above will pick up. Strong-types reflection
+    // does not always expose it, so fall back to a find()-based __contains__ when
+    // none was reflected (still O(log n), never iterating).
+        if (!HasAttrDirect(pyclass, PyStrings::gContains))
+            Utility::AddToClass(pyclass, "__contains__", (PyCFunction)STLContainsWithFind, METH_O);
     }
 
     else if (IsTemplatedSTLClass(name, "pair")) {


### PR DESCRIPTION
Two related fixes, one commit each:

- **std::string:** the `#if __cplusplus <= 202302L` guard drops the `__contains__` pythonization when built with `-std=c++2c` (`__cplusplus == 202400L`). Python's `in` never dispatches to C++23's `std::string::contains` member, so `x in s` breaks. Register unconditionally.
- **set/map:** the `#if __cplusplus <= 202002L` guard assumes native `contains()` is reflected and mapped to `__contains__` past C++20; with strong-types CppInterOp reflection that doesn't always happen, leaving `std::set`/`std::map` with no `__contains__` at all. Replace the compile-time guard with a runtime check: register the `find()`-based fallback only when no `__contains__` was reflected, so native reflection still wins when available.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)