### PR TITLE
Remove support for end-of-life Python versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,18 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 message(STATUS "Looking for python ...")
-set(Python_FIND_VIRTUALENV ONLY)
-find_package (Python COMPONENTS Interpreter Development)
-if (NOT Python_FOUND)
-   set(Python_FIND_VIRTUALENV STANDARD)
-   find_package (Python COMPONENTS Interpreter Development)
+set(Python3_FIND_VIRTUALENV ONLY)
+find_package(Python3 3.10 COMPONENTS Interpreter Development)
+if (NOT Python3_FOUND)
+   set(Python3_FIND_VIRTUALENV STANDARD)
+   find_package(Python3 3.10 COMPONENTS Interpreter Development)
 endif()
 
-if (NOT Python_Development_FOUND)
+if (NOT Python3_Development_FOUND)
    message(FATAL_ERROR "Python development package not found and python component required")
 endif()
 
-include_directories("${PROJECT_SOURCE_DIR}/include" "${Python_INCLUDE_DIRS}")
+include_directories("${PROJECT_SOURCE_DIR}/include" "${Python3_INCLUDE_DIRS}")
 
 file (GLOB cppyy_src src/*.cxx)
 

--- a/src/API.cxx
+++ b/src/API.cxx
@@ -48,22 +48,10 @@ static bool Initialize()
 
     if (!Py_IsInitialized()) {
     // this happens if Cling comes in first
-#if PY_VERSION_HEX < 0x03020000
-        PyEval_InitThreads();
-#endif
-#if PY_VERSION_HEX < 0x03080000
-        Py_Initialize();
-#else
         PyConfig config;
         PyConfig_InitPythonConfig(&config);
         PyConfig_SetString(&config, &config.program_name, L"cppyy");
         Py_InitializeFromConfig(&config);
-#endif
-#if PY_VERSION_HEX >= 0x03020000
-#if PY_VERSION_HEX < 0x03090000
-        PyEval_InitThreads();
-#endif
-#endif
 
     // try again to see if the interpreter is initialized
         if (!Py_IsInitialized()) {
@@ -71,16 +59,6 @@ static bool Initialize()
             std::cerr << "Error: python has not been initialized; returning." << std::endl;
             return false;
         }
-
-   // set the command line arguments on python's sys.argv
-#if PY_VERSION_HEX < 0x03000000
-        char* argv[] = {const_cast<char*>("cppyy")};
-#elif PY_VERSION_HEX < 0x03080000
-        wchar_t* argv[] = {const_cast<wchar_t*>(L"cppyy")};
-#endif
-#if PY_VERSION_HEX < 0x03080000
-        PySys_SetArgv(sizeof(argv)/sizeof(argv[0]), argv);
-#endif
 
     // force loading of the cppyy module
         PyRun_SimpleString(const_cast<char*>("import cppyy"));

--- a/src/CPPClassMethod.cxx
+++ b/src/CPPClassMethod.cxx
@@ -5,11 +5,8 @@
 
 
 //- public members --------------------------------------------------------------
-PyObject* CPyCppyy::CPPClassMethod::Call(CPPInstance*&
-#if PY_VERSION_HEX >= 0x03080000
-    self
-#endif
-    , CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt)
+PyObject *CPyCppyy::CPPClassMethod::Call(CPPInstance *&self, CPyCppyy_PyArgs_t args,
+                                         size_t nargsf, PyObject *kwds, CallContext *ctxt)
 {
 // preliminary check in case keywords are accidently used (they are ignored otherwise)
     if (kwds && ((PyDict_Check(kwds) && PyDict_Size(kwds)) ||
@@ -23,7 +20,6 @@ PyObject* CPyCppyy::CPPClassMethod::Call(CPPInstance*&
         return nullptr;
 
 // translate the arguments
-#if PY_VERSION_HEX >= 0x03080000
 // TODO: The following is not robust and should be revisited e.g. by making CPPOverloads
 // that have only CPPClassMethods be true Python classmethods? Note that the original
 // implementation wasn't 100% correct either (e.g. static size() mapped to len()).
@@ -40,7 +36,6 @@ PyObject* CPyCppyy::CPPClassMethod::Call(CPPInstance*&
             nargsf -= 1;
         }
     }
-#endif
 
     if (!this->ConvertAndSetArgs(args, nargsf, ctxt))
         return nullptr;

--- a/src/CPPConstructor.cxx
+++ b/src/CPPConstructor.cxx
@@ -225,7 +225,6 @@ PyObject* CPyCppyy::CPPMultiConstructor::Call(CPPInstance*& self,
 // TODO: this way of forwarding is expensive as the loop is external to this call;
 // it would be more efficient to have the argument handling happen beforehand
 
-#if PY_VERSION_HEX >= 0x03080000
 // fetch self, verify, and put the arguments in usable order (if self is not handled
 // first, arguments can not be reordered with sentinels in place)
     PyCallArgs cargs{self, argsin, nargsf, kwds};
@@ -243,11 +242,6 @@ PyObject* CPyCppyy::CPPMultiConstructor::Call(CPPInstance*& self,
 
 // copy out self as it may have been updated
     self = cargs.fSelf;
-
-#else
-    PyObject* args = argsin;
-    Py_INCREF(args);
-#endif
 
     if (PyTuple_CheckExact(args) && PyTuple_GET_SIZE(args)) {   // case 0. falls through
         Py_ssize_t nArgs = PyTuple_GET_SIZE(args);
@@ -311,20 +305,13 @@ PyObject* CPyCppyy::CPPMultiConstructor::Call(CPPInstance*& self,
         }
     }
 
-#if PY_VERSION_HEX < 0x03080000
-    Py_ssize_t
-#endif
     nargs = PyTuple_GET_SIZE(args);
 
-#if PY_VERSION_HEX >= 0x03080000
 // now unroll the new args tuple into a vector of objects
     auto argsu = std::unique_ptr<PyObject*[]>{new PyObject*[nargs]};
     for (Py_ssize_t i = 0; i < nargs; ++i)
         argsu[i] = PyTuple_GET_ITEM(args, i);
     CPyCppyy_PyArgs_t _args = argsu.get();
-#else
-    CPyCppyy_PyArgs_t _args = args;
-#endif
 
     PyObject* result = CPPConstructor::Call(self, _args, nargs, kwds, ctxt);
     Py_DECREF(args);
@@ -339,11 +326,9 @@ PyObject* CPyCppyy::CPPAbstractClassConstructor::Call(CPPInstance*& self,
 {
 // do not allow instantiation of abstract classes
     if ((self && GetScope() != self->ObjectIsA()
-#if PY_VERSION_HEX >= 0x03080000
         ) || (!self && !(ctxt->fFlags & CallContext::kFromDescr) && \
               CPyCppyy_PyArgs_GET_SIZE(args, nargsf) && CPPInstance_Check(args[0]) && \
               GetScope() != ((CPPInstance*)args[0])->ObjectIsA()
-#endif
         )) {
     // happens if a dispatcher is inserted; allow constructor call
         return CPPConstructor::Call(self, args, nargsf, kwds, ctxt);

--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -298,19 +298,11 @@ PyTypeObject CPPDataMember_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/CPPEnum.cxx
+++ b/src/CPPEnum.cxx
@@ -33,11 +33,7 @@ PyObject* CPyCppyy::pyval_from_enum(const std::string& enum_type, PyObject* pyty
     PyObject* bval;
     if (enum_type == "char") {
         char val = (char)llval;
-#if PY_VERSION_HEX < 0x03000000
-        bval = CPyCppyy_PyText_FromStringAndSize(&val, 1);
-#else
         bval = PyUnicode_FromOrdinal((int)val);
-#endif
     } else if (enum_type == "int" || enum_type == "unsigned int")
         bval = PyInt_FromLong((long)llval);
     else

--- a/src/CPPExcInstance.cxx
+++ b/src/CPPExcInstance.cxx
@@ -164,9 +164,6 @@ static PyNumberMethods ep_as_number = {
     0,                             // nb_add
     0,                             // nb_subtract
     0,                             // nb_multiply
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_divide
-#endif
     0,                             // nb_remainder
     0,                             // nb_divmod
     0,                             // nb_power
@@ -180,46 +177,26 @@ static PyNumberMethods ep_as_number = {
     0,                             // nb_and
     0,                             // nb_xor
     0,                             // nb_or
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_coerce
-#endif
     0,                             // nb_int
     0,                             // nb_long (nb_reserved in p3)
     0,                             // nb_float
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_oct
-    0,                             // nb_hex
-#endif
     0,                             // nb_inplace_add
     0,                             // nb_inplace_subtract
     0,                             // nb_inplace_multiply
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_inplace_divide
-#endif
     0,                             // nb_inplace_remainder
     0,                             // nb_inplace_power
     0,                             // nb_inplace_lshift
     0,                             // nb_inplace_rshift
     0,                             // nb_inplace_and
     0,                             // nb_inplace_xor
-    0                              // nb_inplace_or
-#if PY_VERSION_HEX >= 0x02020000
-    , 0                            // nb_floor_divide
-#if PY_VERSION_HEX < 0x03000000
-    , 0                            // nb_true_divide
-#else
-    , 0                            // nb_true_divide
-#endif
-    , 0                            // nb_inplace_floor_divide
-    , 0                            // nb_inplace_true_divide
-#endif
-#if PY_VERSION_HEX >= 0x02050000
-    , 0                            // nb_index
-#endif
-#if PY_VERSION_HEX >= 0x03050000
-    , 0                            // nb_matrix_multiply
-    , 0                            // nb_inplace_matrix_multiply
-#endif
+    0,                             // nb_inplace_or
+    0,                             // nb_floor_divide
+    0,                             // nb_true_divide
+    0,                             // nb_inplace_floor_divide
+    0,                             // nb_inplace_true_divide
+    0,                             // nb_index
+    0,                             // nb_matrix_multiply
+    0                              // nb_inplace_matrix_multiply
 };
 
 //= CPyCppyy exception object proxy type ======================================
@@ -272,19 +249,11 @@ PyTypeObject CPPExcInstance_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                            // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/CPPFunction.cxx
+++ b/src/CPPFunction.cxx
@@ -10,7 +10,6 @@
 //- CFunction helpers -----------------------------------------------------------
 bool CPyCppyy::AdjustSelf(PyCallArgs& cargs)
 {
-#if PY_VERSION_HEX >= 0x03080000
     if (cargs.fNArgsf & PY_VECTORCALL_ARGUMENTS_OFFSET) {  // mutation allowed?
         std::swap(((PyObject**)cargs.fArgs-1)[0], (PyObject*&)cargs.fSelf);
         cargs.fFlags |= PyCallArgs::kSelfSwap;
@@ -31,21 +30,6 @@ bool CPyCppyy::AdjustSelf(PyCallArgs& cargs)
         cargs.fFlags |= PyCallArgs::kDoFree;
         cargs.fNArgsf += 1;
     }
-#else
-    Py_ssize_t sz = PyTuple_GET_SIZE(cargs.fArgs);
-    CPyCppyy_PyArgs_t newArgs = PyTuple_New(sz+1);
-    for (int i = 0; i < sz; ++i) {
-        PyObject* item = PyTuple_GET_ITEM(cargs.fArgs, i);
-        Py_INCREF(item);
-        PyTuple_SET_ITEM(newArgs, i+1, item);
-    }
-    Py_INCREF(cargs.fSelf);
-    PyTuple_SET_ITEM(newArgs, 0, (PyObject*)cargs.fSelf);
-
-    cargs.fArgs = newArgs;
-    cargs.fFlags |= PyCallArgs::kDoDecref;
-    cargs.fNArgsf += 1;
-#endif
     return true;
 }
 
@@ -73,14 +57,12 @@ PyObject* CPyCppyy::CPPFunction::Call(CPPInstance*& self,
             return nullptr;
     }
 
-#if PY_VERSION_HEX >= 0x03080000
 // special case, if this method was inserted as a constructor, then self is nullptr
 // and it will be the first argument and needs to be used as Python context
     if (IsConstructor(ctxt->fFlags) && !ctxt->fPyContext && \
             CPyCppyy_PyArgs_GET_SIZE(cargs.fArgs, cargs.fNArgsf)) {
         ctxt->fPyContext = cargs.fArgs[0];
     }
-#endif
 
 // translate the arguments as normal
     if (!this->ConvertAndSetArgs(cargs.fArgs, cargs.fNArgsf, ctxt))
@@ -89,7 +71,6 @@ PyObject* CPyCppyy::CPPFunction::Call(CPPInstance*& self,
 // execute function
     PyObject* result = this->Execute(nullptr, 0, ctxt);
 
-#if PY_VERSION_HEX >= 0x03080000
 // special case, if this method was inserted as a constructor, then if no self was
 // provided, it will be the first argument and may have been updated
     if (IsConstructor(ctxt->fFlags) && result && !cargs.fSelf && \
@@ -97,7 +78,6 @@ PyObject* CPyCppyy::CPPFunction::Call(CPPInstance*& self,
         self = (CPPInstance*)cargs.fArgs[0];
         Py_INCREF(self);
     }
-#endif
 
     return result;
 }
@@ -121,11 +101,7 @@ bool CPyCppyy::CPPReverseBinary::ProcessArgs(PyCallArgs& cargs)
     }
 
 // swap the arguments
-#if PY_VERSION_HEX >= 0x03080000
     std::swap(((PyObject**)cargs.fArgs)[0], ((PyObject**)cargs.fArgs)[1]);
-#else
-    std::swap(PyTuple_GET_ITEM(cargs.fArgs, 0), PyTuple_GET_ITEM(cargs.fArgs, 1));
-#endif
     cargs.fFlags |= PyCallArgs::kArgsSwap;
 
     return true;

--- a/src/CPPGetSetItem.cxx
+++ b/src/CPPGetSetItem.cxx
@@ -64,22 +64,12 @@ bool CPyCppyy::CPPSetItem::ProcessArgs(PyCallArgs& cargs)
     }
 
 // unroll any tuples, if present in the arguments
-#if PY_VERSION_HEX >= 0x03080000
     if (realsize != nArgs-1) {
         CPyCppyy_PyArgs_t unrolled = (PyObject**)PyMem_Malloc(realsize * sizeof(PyObject*));
         unroll(cargs.fArgs, unrolled, nArgs-1);
         cargs.fArgs = unrolled;
         cargs.fFlags |= PyCallArgs::kDoFree;
     }
-#else
-    if (realsize != nArgs-1) {
-        CPyCppyy_PyArgs_t unrolled = PyTuple_New(realsize);
-        unroll(cargs.fArgs, unrolled, nArgs-1);
-        cargs.fArgs = unrolled;
-    } else
-        cargs.fArgs = PyTuple_GetSlice(cargs.fArgs, 0, nArgs-1);
-    cargs.fFlags |= PyCallArgs::kDoDecref;
-#endif
     cargs.fNArgsf = realsize;
 
 // continue normal method processing
@@ -103,13 +93,8 @@ bool CPyCppyy::CPPGetItem::ProcessArgs(PyCallArgs& cargs)
 // unroll any tuples, if present in the arguments
     if (realsize != nArgs) {
         CPyCppyy_PyArgs_t packed_args = cargs.fArgs;
-#if PY_VERSION_HEX >= 0x03080000
         cargs.fArgs = (PyObject**)PyMem_Malloc(realsize * sizeof(PyObject*));
         cargs.fFlags |= PyCallArgs::kDoFree;
-#else
-        cargs.fArgs = PyTuple_New(realsize);
-        cargs.fFlags |= PyCallArgs::kDoDecref;
-#endif
         cargs.fNArgsf = realsize;
         unroll(packed_args, cargs.fArgs, nArgs);
     }

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -748,21 +748,17 @@ static PyObject* op_str_internal(PyObject* pyobj, PyObject* lshift, bool isBound
     std::ostringstream s;
     PyObject* pys = BindCppObjectNoCast(&s, sOStringStreamID);
     Py_INCREF(pys);
-#if PY_VERSION_HEX >= 0x03000000
 // for py3 and later, a ref-count of 2 is okay to consider the object temporary, but
 // in this case, we can't lose our existing ostrinstring (otherwise, we'd have to peel
 // it out of the return value, if moves are used
     Py_INCREF(pys);
-#endif
 
     PyObject* res;
     if (isBound) res = PyObject_CallFunctionObjArgs(lshift, pys, NULL);
     else res = PyObject_CallFunctionObjArgs(lshift, pys, pyobj, NULL);
 
     Py_DECREF(pys);
-#if PY_VERSION_HEX >= 0x03000000
     Py_DECREF(pys);
-#endif
 
     if (res) {
         Py_DECREF(res);
@@ -1014,9 +1010,6 @@ static PyNumberMethods op_as_number = {
     (binaryfunc)op_add_stub,       // nb_add
     (binaryfunc)op_sub_stub,       // nb_subtract
     (binaryfunc)op_mul_stub,       // nb_multiply
-#if PY_VERSION_HEX < 0x03000000
-    (binaryfunc)op_div_stub,       // nb_divide
-#endif
     0,                             // nb_remainder
     0,                             // nb_divmod
     0,                             // nb_power
@@ -1030,46 +1023,26 @@ static PyNumberMethods op_as_number = {
     0,                             // nb_and
     0,                             // nb_xor
     0,                             // nb_or
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_coerce
-#endif
     0,                             // nb_int
     0,                             // nb_long (nb_reserved in p3)
     0,                             // nb_float
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_oct
-    0,                             // nb_hex
-#endif
     0,                             // nb_inplace_add
     0,                             // nb_inplace_subtract
     0,                             // nb_inplace_multiply
-#if PY_VERSION_HEX < 0x03000000
-    0,                             // nb_inplace_divide
-#endif
     0,                             // nb_inplace_remainder
     0,                             // nb_inplace_power
     0,                             // nb_inplace_lshift
     0,                             // nb_inplace_rshift
     0,                             // nb_inplace_and
     0,                             // nb_inplace_xor
-    0                              // nb_inplace_or
-#if PY_VERSION_HEX >= 0x02020000
-    , 0                            // nb_floor_divide
-#if PY_VERSION_HEX < 0x03000000
-    , 0                            // nb_true_divide
-#else
-    , (binaryfunc)op_div_stub      // nb_true_divide
-#endif
-    , 0                            // nb_inplace_floor_divide
-    , 0                            // nb_inplace_true_divide
-#endif
-#if PY_VERSION_HEX >= 0x02050000
-    , 0                            // nb_index
-#endif
-#if PY_VERSION_HEX >= 0x03050000
-    , 0                            // nb_matrix_multiply
-    , 0                            // nb_inplace_matrix_multiply
-#endif
+    0,                             // nb_inplace_or
+    0,                             // nb_floor_divide
+    (binaryfunc)op_div_stub,       // nb_true_divide
+    0,                             // nb_inplace_floor_divide
+    0,                             // nb_inplace_true_divide
+    0,                             // nb_index
+    0,                             // nb_matrix_multiply
+    0                              // nb_inplace_matrix_multiply
 };
 
 
@@ -1122,19 +1095,11 @@ PyTypeObject CPPInstance_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -41,7 +41,6 @@ CPyCppyy::PyCallArgs::~PyCallArgs() {
     if (fFlags & kSelfSwap)            // if self swap, fArgs has been offset by -1
         std::swap((PyObject*&)fSelf, ((PyObject**)fArgs)[0]);
 
-#if PY_VERSION_HEX >= 0x03080000
     if (fFlags & kIsOffset) fArgs -= 1;
 
     if (fFlags & kDoItemDecref) {
@@ -56,12 +55,6 @@ CPyCppyy::PyCallArgs::~PyCallArgs() {
         int offset = (fFlags & kSelfSwap) ? 1 : 0;
         std::swap(((PyObject**)fArgs+offset)[0], ((PyObject**)fArgs+offset)[1]);
     }
-#else
-    if (fFlags & kDoDecref)
-        Py_DECREF((PyObject*)fArgs);
-    else if (fFlags & kArgsSwap)
-        std::swap(PyTuple_GET_ITEM(fArgs, 0), PyTuple_GET_ITEM(fArgs, 1));
-#endif
 }
 
 
@@ -708,11 +701,7 @@ PyObject* CPyCppyy::CPPMethod::GetArgDefault(int iarg, bool silent)
 
         PyObject* pycode = Py_CompileString((char*)defvalue.c_str(), "cppyy_default_compiler", Py_eval_input);
         if (pycode) {
-            pyval = PyEval_EvalCode(
-#if PY_VERSION_HEX < 0x03000000
-                (PyCodeObject*)
-#endif
-                pycode, gdct, gdct);
+            pyval = PyEval_EvalCode(pycode, gdct, gdct);
             Py_DECREF(pycode);
         }
 
@@ -806,19 +795,11 @@ bool CPyCppyy::CPPMethod::Initialize(CallContext* ctxt)
 //----------------------------------------------------------------------------
 bool CPyCppyy::CPPMethod::ProcessKwds(PyObject* self_in, PyCallArgs& cargs)
 {
-#if PY_VERSION_HEX >= 0x03080000
     if (!PyTuple_CheckExact(cargs.fKwds)) {
         SetPyError_(CPyCppyy_PyText_FromString("received unknown keyword names object"));
         return false;
     }
     Py_ssize_t nKeys = PyTuple_GET_SIZE(cargs.fKwds);
-#else
-    if (!PyDict_CheckExact(cargs.fKwds)) {
-        SetPyError_(CPyCppyy_PyText_FromString("received unknown keyword arguments object"));
-        return false;
-    }
-    Py_ssize_t nKeys = PyDict_Size(cargs.fKwds);
-#endif
 
     if (nKeys == 0 && !self_in)
         return true;
@@ -839,15 +820,10 @@ bool CPyCppyy::CPPMethod::ProcessKwds(PyObject* self_in, PyCallArgs& cargs)
     PyObject *key, *value;
     Py_ssize_t maxpos = -1;
 
-#if PY_VERSION_HEX >= 0x03080000
     Py_ssize_t npos_args = CPyCppyy_PyArgs_GET_SIZE(cargs.fArgs, cargs.fNArgsf);
     for (Py_ssize_t ikey = 0; ikey < nKeys; ++ikey) {
         key = PyTuple_GET_ITEM(cargs.fKwds, ikey);
         value = cargs.fArgs[npos_args+ikey];
-#else
-    Py_ssize_t pos = 0;
-    while (PyDict_Next(cargs.fKwds, &pos, &key, &value)) {
-#endif
         const char* ckey = CPyCppyy_PyText_AsStringChecked(key);
         if (!ckey)
             return false;
@@ -910,23 +886,15 @@ bool CPyCppyy::CPPMethod::ProcessKwds(PyObject* self_in, PyCallArgs& cargs)
         }
     }
 
-#if PY_VERSION_HEX >= 0x03080000
     if (cargs.fFlags & PyCallArgs::kDoFree) {
         if (cargs.fFlags & PyCallArgs::kIsOffset)
             cargs.fArgs -= 1;
-#else
-    if (cargs.fFlags & PyCallArgs::kDoDecref) {
-#endif
        CPyCppyy_PyArgs_DEL(cargs.fArgs);
     }
 
     cargs.fArgs = newArgs;
     cargs.fNArgsf = maxargs;
-#if PY_VERSION_HEX >= 0x03080000
     cargs.fFlags = PyCallArgs::kDoFree | PyCallArgs::kDoItemDecref;
-#else
-    cargs.fFlags = PyCallArgs::kDoDecref;
-#endif
 
     return true;
 }
@@ -957,15 +925,8 @@ bool CPyCppyy::CPPMethod::ProcessArgs(PyCallArgs& cargs)
                 cargs.fSelf = pyobj;
 
             // offset args by 1
-#if PY_VERSION_HEX >= 0x03080000
                 cargs.fArgs += 1;
                 cargs.fFlags |= PyCallArgs::kIsOffset;
-#else
-                if (cargs.fFlags & PyCallArgs::kDoDecref)
-                    Py_DECREF((PyObject*)cargs.fArgs);
-                cargs.fArgs = PyTuple_GetSlice(cargs.fArgs, 1, PyTuple_GET_SIZE(cargs.fArgs));
-                cargs.fFlags |= PyCallArgs::kDoDecref;
-#endif
                 cargs.fNArgsf -= 1;
 
             // put the keywords, if any, in their places in the arguments array

--- a/src/CPPMethod.h
+++ b/src/CPPMethod.h
@@ -26,12 +26,8 @@ public:
         kIsOffset       = 0x0001, // args were offset by 1 to drop self
         kSelfSwap       = 0x0002, // args[-1] and self need swapping
         kArgsSwap       = 0x0004, // args[0] and args[1] need swapping
-#if PY_VERSION_HEX >= 0x03080000
         kDoFree         = 0x0008, // args need to be free'd (vector call only)
         kDoItemDecref   = 0x0010  // items in args need a decref (vector call only)
-#else
-        kDoDecref       = 0x0020  // args need a decref
-#endif
     };
 
 public:

--- a/src/CPPOperator.cxx
+++ b/src/CPPOperator.cxx
@@ -14,11 +14,7 @@ CPyCppyy::CPPOperator::CPPOperator(
     if (name == "__mul__")
         fStub = CPPInstance_Type.tp_as_number->nb_multiply;
     else if (name == CPPYY__div__)
-#if PY_VERSION_HEX < 0x03000000
-        fStub = CPPInstance_Type.tp_as_number->nb_divide;
-#else
         fStub = CPPInstance_Type.tp_as_number->nb_true_divide;
-#endif
     else if (name == "__add__")
         fStub = CPPInstance_Type.tp_as_number->nb_add;
     else if (name == "__sub__")
@@ -42,11 +38,9 @@ PyObject* CPyCppyy::CPPOperator::Call(CPPInstance*& self,
 
     Py_ssize_t idx_other = 0;
     if (CPyCppyy_PyArgs_GET_SIZE(args, nargsf) != 1) {
-#if PY_VERSION_HEX >= 0x03080000
         if ((CPyCppyy_PyArgs_GET_SIZE(args, nargsf) == 2 && CPyCppyy_PyArgs_GET_ITEM(args, 0) == (PyObject*)self))
             idx_other = 1;
         else
-#endif
         return result;
     }
 

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -2,12 +2,8 @@
 #include "CPyCppyy.h"
 #include "CPyCppyy/Reflex.h"
 #include "structmember.h"    // from Python
-#if PY_VERSION_HEX >= 0x02050000
 #if PY_VERSION_HEX <  0x030b0000
 #include "code.h"            // from Python
-#endif
-#else
-#include "compile.h"         // from Python
 #endif
 #ifndef CO_NOFREE
 // python2.2 does not have CO_NOFREE defined
@@ -103,7 +99,6 @@ public:
     PyObject* Call(CPPInstance*& self,
             CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* /* ctxt = 0 */) override {
 
-#if PY_VERSION_HEX >= 0x03080000
         if (self) {
             if (nargsf & PY_VECTORCALL_ARGUMENTS_OFFSET) {      // mutation allowed?
                 std::swap(((PyObject**)args-1)[0], (PyObject*&)self);
@@ -130,25 +125,6 @@ public:
                 std::swap(((PyObject**)args-1)[0], (PyObject*&)self);
             else PyMem_Free((void*)args);
         }
-#else
-        PyObject* newArgs = nullptr;
-        if (self) {
-            Py_ssize_t nargs = PyTuple_Size(args);
-            newArgs = PyTuple_New(nargs+1);
-            Py_INCREF(self);
-            PyTuple_SET_ITEM(newArgs, 0, (PyObject*)self);
-            for (Py_ssize_t iarg = 0; iarg < nargs; ++iarg) {
-                PyObject* pyarg = PyTuple_GET_ITEM(args, iarg);
-                Py_INCREF(pyarg);
-                PyTuple_SET_ITEM(newArgs, iarg+1, pyarg);
-            }
-        } else {
-            Py_INCREF(args);
-            newArgs = args;
-        }
-        PyObject* result = PyObject_Call(fCallable, newArgs, kwds);
-        Py_DECREF(newArgs);
-#endif
         return result;
     }
 };
@@ -396,83 +372,12 @@ static PyObject* mp_func_closure(CPPOverload* /* pymeth */, void*)
     Py_RETURN_NONE;
 }
 
-// To declare a variable as unused only when compiling for Python 3.
-#if PY_VERSION_HEX < 0x03000000
-#define CPyCppyy_Py3_UNUSED(name) name
-#else
-#define CPyCppyy_Py3_UNUSED(name)
-#endif
-
 //----------------------------------------------------------------------------
-static PyObject* mp_func_code(CPPOverload* CPyCppyy_Py3_UNUSED(pymeth), void*)
+static PyObject* mp_func_code(CPPOverload*, void*)
 {
 // Code details are used in module inspect to fill out interactive help()
-#if PY_VERSION_HEX < 0x03000000
-    CPPOverload::Methods_t& methods = pymeth->fMethodInfo->fMethods;
-
-// collect arguments only if there is just 1 overload, otherwise put in a
-// fake *args (see below for co_varnames)
-    PyObject* co_varnames = methods.size() == 1 ? methods[0]->GetCoVarNames() : nullptr;
-    if (!co_varnames) {
-    // TODO: static methods need no 'self' (but is harmless otherwise)
-        co_varnames = PyTuple_New(1 /* self */ + 1 /* fake */);
-        PyTuple_SET_ITEM(co_varnames, 0, CPyCppyy_PyText_FromString("self"));
-        PyTuple_SET_ITEM(co_varnames, 1, CPyCppyy_PyText_FromString("*args"));
-    }
-
-    int co_argcount = (int)PyTuple_Size(co_varnames);
-
-// for now, code object representing the statement 'pass'
-    PyObject* co_code = PyString_FromStringAndSize("d\x00\x00S", 4);
-
-// tuples with all the const literals used in the function
-    PyObject* co_consts = PyTuple_New(0);
-    PyObject* co_names = PyTuple_New(0);
-
-// names, freevars, and cellvars go unused
-    PyObject* co_unused = PyTuple_New(0);
-
-// filename is made-up
-    PyObject* co_filename = PyString_FromString("cppyy.py");
-
-// name is the function name, also through __name__ on the function itself
-    PyObject* co_name = PyString_FromString(pymeth->GetName().c_str());
-
-// firstlineno is the line number of first function code in the containing scope
-
-// lnotab is a packed table that maps instruction count and line number
-    PyObject* co_lnotab = PyString_FromString("\x00\x01\x0c\x01");
-
-    PyObject* code = (PyObject*)PyCode_New(
-        co_argcount,                             // argcount
-        co_argcount+1,                           // nlocals
-        2,                                       // stacksize
-        CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE, // flags
-        co_code,                                 // code
-        co_consts,                               // consts
-        co_names,                                // names
-        co_varnames,                             // varnames
-        co_unused,                               // freevars
-        co_unused,                               // cellvars
-        co_filename,                             // filename
-        co_name,                                 // name
-        1,                                       // firstlineno
-        co_lnotab);                              // lnotab
-
-    Py_DECREF(co_lnotab);
-    Py_DECREF(co_name);
-    Py_DECREF(co_unused);
-    Py_DECREF(co_filename);
-    Py_DECREF(co_varnames);
-    Py_DECREF(co_names);
-    Py_DECREF(co_consts);
-    Py_DECREF(co_code);
-
-    return code;
-#else
 // not important for functioning of most code, so not implemented for p3 for now (TODO)
     Py_RETURN_NONE;
-#endif
 }
 
 //----------------------------------------------------------------------------
@@ -661,17 +566,9 @@ static PyGetSetDef mp_getset[] = {
 };
 
 //= CPyCppyy method proxy function behavior ==================================
-#if PY_VERSION_HEX >= 0x03080000
 static PyObject* mp_vectorcall(
     CPPOverload* pymeth, PyObject* const *args, size_t nargsf, PyObject* kwds)
-#else
-static PyObject* mp_call(CPPOverload* pymeth, PyObject* args, PyObject* kwds)
-#endif
 {
-#if PY_VERSION_HEX < 0x03080000
-    size_t nargsf = PyTuple_GET_SIZE(args);
-#endif
-
 // Call the appropriate overload of this method.
 
 // If called from a descriptor, then this could be a bound function with
@@ -840,15 +737,6 @@ static CPPOverload* mp_descr_get(CPPOverload* pymeth, CPPInstance* pyobj, PyObje
 //     py3.8 <=       | vector calls no longer call the descriptor, so when it is
 //                    |  called, the method is likely stored, so should be new object
 
-#if PY_VERSION_HEX < 0x03080000
-    if (!pyobj || (PyObject*)pyobj == Py_None /* from unbound TemplateProxy */) {
-        Py_XDECREF(pymeth->fSelf); pymeth->fSelf = nullptr;
-        pymeth->fFlags |= CallContext::kCallDirect | CallContext::kFromDescr;
-        Py_INCREF(pymeth);
-        return pymeth;       // unbound, e.g. free functions
-    }
-#endif
-
 // create a new method object
     bool gc_track = false;
     CPPOverload* newPyMeth = free_list;
@@ -867,7 +755,6 @@ static CPPOverload* mp_descr_get(CPPOverload* pymeth, CPPInstance* pyobj, PyObje
     *pymeth->fMethodInfo->fRefCount += 1;
     newPyMeth->fMethodInfo = pymeth->fMethodInfo;
 
-#if PY_VERSION_HEX >= 0x03080000
     newPyMeth->fVectorCall = pymeth->fVectorCall;
 
     if (pyobj && (PyObject*)pyobj != Py_None) {
@@ -882,17 +769,6 @@ static CPPOverload* mp_descr_get(CPPOverload* pymeth, CPPInstance* pyobj, PyObje
 // vector calls don't get here, unless a method is looked up on an instance, for
 // e.g. class methods (C++ static); notify downstream to expect a 'self'
     newPyMeth->fFlags |= CallContext::kFromDescr;
-
-#else
-// new method is to be bound to current object
-    Py_INCREF((PyObject*)pyobj);
-    newPyMeth->fSelf = pyobj;
-
-// reset flags of the new method, as there is a self (which may or may not have
-// come in through direct call syntax, but that's now impossible to know, so this
-// is the safer choice)
-    newPyMeth->fFlags = CallContext::kNone;
-#endif
 
     if (gc_track)
         PyObject_GC_Track(newPyMeth);
@@ -1045,11 +921,7 @@ PyTypeObject CPPOverload_Type = {
     sizeof(CPPOverload),               // tp_basicsize
     0,                                 // tp_itemsize
     (destructor)mp_dealloc,            // tp_dealloc
-#if PY_VERSION_HEX >= 0x03080000
     offsetof(CPPOverload, fVectorCall),
-#else
-    0,                                 // tp_vectorcall_offset / tp_print
-#endif
     0,                                 // tp_getattr
     0,                                 // tp_setattr
     0,                                 // tp_as_async / tp_compare
@@ -1058,20 +930,13 @@ PyTypeObject CPPOverload_Type = {
     0,                                 // tp_as_sequence
     0,                                 // tp_as_mapping
     (hashfunc)mp_hash,                 // tp_hash
-#if PY_VERSION_HEX >= 0x03080000
     (ternaryfunc)PyVectorcall_Call,    // tp_call
-#else
-    (ternaryfunc)mp_call,              // tp_call
-#endif
     (reprfunc)mp_str,                  // tp_str
     0,                                 // tp_getattro
     0,                                 // tp_setattro
     0,                                 // tp_as_buffer
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC
-#if PY_VERSION_HEX >= 0x03080000
-        | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR
-#endif
-    ,                                  // tp_flags
+        | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR, // tp_flags
     (char*)"cppyy method proxy (internal)", // tp_doc
     (traverseproc)mp_traverse,         // tp_traverse
     (inquiry)mp_clear,                 // tp_clear
@@ -1096,19 +961,11 @@ PyTypeObject CPPOverload_Type = {
     0,                                 // tp_mro
     0,                                 // tp_cache
     0,                                 // tp_subclasses
-    0                                  // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                                // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                                // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                                // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                                // tp_vectorcall
-#endif
+    0,                                 // tp_weaklist
+    0,                                 // tp_del
+    0,                                 // tp_version_tag
+    0,                                 // tp_finalize
+    0                                  // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -1132,9 +989,7 @@ void CPyCppyy::CPPOverload::Set(const std::string& name, std::vector<PyCallable*
             name.find("Clone") != std::string::npos)
         fMethodInfo->fFlags |= CallContext::kIsCreator;
 
-#if PY_VERSION_HEX >= 0x03080000
     fVectorCall = (vectorcallfunc)mp_vectorcall;
-#endif
 }
 
 //----------------------------------------------------------------------------

--- a/src/CPPOverload.h
+++ b/src/CPPOverload.h
@@ -78,9 +78,7 @@ public:                 // public, as the python C-API works with C structs
     CPPInstance*   fSelf;         // must be first (same layout as TemplateProxy)
     MethodInfo_t*  fMethodInfo;
     uint32_t       fFlags;
-#if PY_VERSION_HEX >= 0x03080000
     vectorcallfunc fVectorCall;
-#endif
 
 private:
     CPPOverload() = delete;

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -664,11 +664,7 @@ PyTypeObject CPPScope_Type = {
     (getattrofunc)meta_getattro,   // tp_getattro
     (setattrofunc)meta_setattro,   // tp_setattro
     0,                             // tp_as_buffer
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE
-#if PY_VERSION_HEX >= 0x03040000
-        | Py_TPFLAGS_TYPE_SUBCLASS
-#endif
-        ,                          // tp_flags
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS, // tp_flags
     (char*)"CPyCppyy metatype (internal)",        // tp_doc
     0,                             // tp_traverse
     0,                             // tp_clear
@@ -693,19 +689,11 @@ PyTypeObject CPPScope_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/CPyCppyy.h
+++ b/src/CPyCppyy.h
@@ -39,96 +39,22 @@ namespace CPyCppyy {
     typedef Py_ssize_t dim_t;
 } // namespace CPyCppyy
 
-// for 3.3 support
-#if PY_VERSION_HEX < 0x03030000
-   typedef PyDictEntry* (*dict_lookup_func)(PyDictObject*, PyObject*, long);
-#else
 #if PY_VERSION_HEX >= 0x030b0000
    typedef Py_ssize_t (*dict_lookup_func)(
        PyDictObject*, PyObject*, Py_hash_t, PyObject**);
-#elif PY_VERSION_HEX >= 0x03060000
+#else
    typedef Py_ssize_t (*dict_lookup_func)(
        PyDictObject*, PyObject*, Py_hash_t, PyObject***, Py_ssize_t*);
-#else
-   struct PyDictKeyEntry;
-   typedef PyDictKeyEntry* (*dict_lookup_func)(PyDictObject*, PyObject*, Py_hash_t, PyObject***);
-#define PyDictEntry PyDictKeyEntry
-#endif
 #endif
 
 // for 3.0 support (backwards compatibility, really)
-#if PY_VERSION_HEX < 0x03000000
-#define PyBytes_Check                  PyString_Check
-#define PyBytes_CheckExact             PyString_CheckExact
-#define PyBytes_AS_STRING              PyString_AS_STRING
-#define PyBytes_AsString               PyString_AsString
-#define PyBytes_AsStringAndSize        PyString_AsStringAndSize
-#define PyBytes_GET_SIZE               PyString_GET_SIZE
-#define PyBytes_Size                   PyString_Size
-#define PyBytes_FromFormat             PyString_FromFormat
-#define PyBytes_FromString             PyString_FromString
-#define PyBytes_FromStringAndSize      PyString_FromStringAndSize
-
-#define PyBytes_Type    PyString_Type
-
-#define CPyCppyy_PyText_Check                 PyString_Check
-#define CPyCppyy_PyText_CheckExact            PyString_CheckExact
-#define CPyCppyy_PyText_AsString              PyString_AS_STRING
-#define CPyCppyy_PyText_AsStringChecked       PyString_AsString
-#define CPyCppyy_PyText_GET_SIZE              PyString_GET_SIZE
-#define CPyCppyy_PyText_GetSize               PyString_Size
-#define CPyCppyy_PyText_FromFormat            PyString_FromFormat
-#define CPyCppyy_PyText_FromString            PyString_FromString
-#define CPyCppyy_PyText_InternFromString      PyString_InternFromString
-#define CPyCppyy_PyText_Append                PyString_Concat
-#define CPyCppyy_PyText_AppendAndDel          PyString_ConcatAndDel
-#define CPyCppyy_PyText_FromStringAndSize     PyString_FromStringAndSize
-
-static inline const char* CPyCppyy_PyText_AsStringAndSize(PyObject* pystr, Py_ssize_t* size)
-{
-    const char* cstr = CPyCppyy_PyText_AsStringChecked(pystr);
-    if (cstr) *size = CPyCppyy_PyText_GetSize(pystr);
-    return cstr;
-}
-
-#define CPyCppyy_PyText_Type PyString_Type
-
-#define CPyCppyy_PyUnicode_GET_SIZE           PyUnicode_GET_SIZE
-
-static inline PyObject* CPyCppyy_PyCapsule_New(
-        void* cobj, const char* /* name */, void (*destr)(void*))
-{
-    return PyCObject_FromVoidPtr(cobj, destr);
-}
-#define CPyCppyy_PyCapsule_CheckExact    PyCObject_Check
-static inline void* CPyCppyy_PyCapsule_GetPointer(PyObject* capsule, const char* /* name */)
-{
-    return (void*)PyCObject_AsVoidPtr(capsule);
-}
-
-#define CPPYY__long__ "__long__"
-#define CPPYY__idiv__ "__idiv__"
-#define CPPYY__div__  "__div__"
-#define CPPYY__next__ "next"
-
-typedef long Py_hash_t;
-
-#endif  // ! 3.0
-
-// for 3.0 support (backwards compatibility, really)
-#if PY_VERSION_HEX >= 0x03000000
 #define CPyCppyy_PyText_Check              PyUnicode_Check
 #define CPyCppyy_PyText_CheckExact         PyUnicode_CheckExact
 #define CPyCppyy_PyText_AsString           PyUnicode_AsUTF8
 #define CPyCppyy_PyText_AsStringChecked    PyUnicode_AsUTF8
 #define CPyCppyy_PyText_GetSize            PyUnicode_GetSize
-#if PY_VERSION_HEX < 0x03090000
-#define CPyCppyy_PyText_GET_SIZE           PyUnicode_GET_SIZE
-#define CPyCppyy_PyUnicode_GET_SIZE        PyUnicode_GET_LENGTH
-#else
 #define CPyCppyy_PyText_GET_SIZE           PyUnicode_GET_LENGTH
 #define CPyCppyy_PyUnicode_GET_SIZE        PyUnicode_GET_LENGTH
-#endif
 #define CPyCppyy_PyText_FromFormat         PyUnicode_FromFormat
 #define CPyCppyy_PyText_FromString         PyUnicode_FromString
 #define CPyCppyy_PyText_InternFromString   PyUnicode_InternFromString
@@ -136,11 +62,7 @@ typedef long Py_hash_t;
 #define CPyCppyy_PyText_AppendAndDel       PyUnicode_AppendAndDel
 #define CPyCppyy_PyText_FromStringAndSize  PyUnicode_FromStringAndSize
 
-#if PY_VERSION_HEX >= 0x03030000
 #define _CPyCppyy_PyText_AsStringAndSize   PyUnicode_AsUTF8AndSize
-#else
-#define _CPyCppyy_PyText_AsStringAndSize   PyUnicode_AsStringAndSize
-#endif  // >= 3.3
 
 static inline const char* CPyCppyy_PyText_AsStringAndSize(PyObject* pystr, Py_ssize_t* size)
 {
@@ -180,88 +102,24 @@ static inline const char* CPyCppyy_PyText_AsStringAndSize(PyObject* pystr, Py_ss
 #define PyClass_Check   PyType_Check
 
 #define PyBuffer_Type   PyMemoryView_Type
-#endif  // ! 3.0
 
-#if PY_VERSION_HEX >= 0x03020000
 #define CPyCppyy_PySliceCast   PyObject*
 #define PyUnicode_GetSize      PyUnicode_GetLength
-#else
-#define CPyCppyy_PySliceCast   PySliceObject*
-#endif  // >= 3.2
 
-// feature of 3.0 not in 2.5 and earlier
-#if PY_VERSION_HEX < 0x02060000
-#define PyVarObject_HEAD_INIT(type, size)                                     \
-    PyObject_HEAD_INIT(type) size,
-#define Py_TYPE(ob)             (((PyObject*)(ob))->ob_type)
-#endif
-
-// API changes in 2.5 (int -> Py_ssize_t) and 3.2 (PyUnicodeObject -> PyObject)
-#if PY_VERSION_HEX < 0x03020000
-static inline Py_ssize_t CPyCppyy_PyUnicode_AsWideChar(PyObject* pyobj, wchar_t* w, Py_ssize_t size)
-{
-#if PY_VERSION_HEX < 0x02050000
-     return (Py_ssize_t)PyUnicode_AsWideChar((PyUnicodeObject*)pyobj, w, (int)size);
-#else
-     return PyUnicode_AsWideChar((PyUnicodeObject*)pyobj, w, size);
-#endif
-}
-#else
 #define CPyCppyy_PyUnicode_AsWideChar PyUnicode_AsWideChar
-#endif
 
-// backwards compatibility, pre python 2.5
-#if PY_VERSION_HEX < 0x02050000
-typedef int Py_ssize_t;
-#define PyInt_AsSsize_t PyInt_AsLong
-#define PyInt_FromSsize_t PyInt_FromLong
-# define PY_SSIZE_T_FORMAT "%d"
-# if !defined(PY_SSIZE_T_MIN)
-#  define PY_SSIZE_T_MAX INT_MAX
-#  define PY_SSIZE_T_MIN INT_MIN
+#ifdef R__MACOSX
+# if SIZEOF_SIZE_T == SIZEOF_INT
+#   if defined(MAC_OS_X_VERSION_10_4)
+#      define PY_SSIZE_T_FORMAT "%ld"
+#   else
+#      define PY_SSIZE_T_FORMAT "%d"
+#   endif
+# elif SIZEOF_SIZE_T == SIZEOF_LONG
+#   define PY_SSIZE_T_FORMAT "%ld"
 # endif
-#define ssizeobjargproc intobjargproc
-#define lenfunc         inquiry
-#define ssizeargfunc    intargfunc
-
-#define PyIndex_Check(obj)                                                    \
-    (PyInt_Check(obj) || PyLong_Check(obj))
-
-inline Py_ssize_t PyNumber_AsSsize_t(PyObject* obj, PyObject*) {
-    return (Py_ssize_t)PyLong_AsLong(obj);
-}
-
 #else
-# ifdef R__MACOSX
-#  if SIZEOF_SIZE_T == SIZEOF_INT
-#    if defined(MAC_OS_X_VERSION_10_4)
-#       define PY_SSIZE_T_FORMAT "%ld"
-#    else
-#       define PY_SSIZE_T_FORMAT "%d"
-#    endif
-#  elif SIZEOF_SIZE_T == SIZEOF_LONG
-#    define PY_SSIZE_T_FORMAT "%ld"
-#  endif
-# else
-#  define PY_SSIZE_T_FORMAT "%zd"
-# endif
-#endif
-
-#if PY_VERSION_HEX < 0x02020000
-#define PyBool_FromLong  PyInt_FromLong
-#endif
-
-#if PY_VERSION_HEX < 0x03000000
-// the following should quiet Solaris
-#ifdef Py_False
-#undef Py_False
-#define Py_False ((PyObject*)(void*)&_Py_ZeroStruct)
-#endif
-
-#ifdef Py_True
-#undef Py_True
-#define Py_True ((PyObject*)(void*)&_Py_TrueStruct)
-#endif
+# define PY_SSIZE_T_FORMAT "%zd"
 #endif
 
 #ifndef Py_RETURN_NONE
@@ -277,14 +135,9 @@ inline Py_ssize_t PyNumber_AsSsize_t(PyObject* obj, PyObject*) {
 #endif
 
 // vector call support
-#if PY_VERSION_HEX >= 0x03090000
 #define CPyCppyy_PyCFunction_Call PyObject_Call
-#else
-#define CPyCppyy_PyCFunction_Call PyCFunction_Call
-#endif
 
 // vector call support
-#if PY_VERSION_HEX >= 0x03080000
 typedef PyObject* const* CPyCppyy_PyArgs_t;
 static inline PyObject* CPyCppyy_PyArgs_GET_ITEM(CPyCppyy_PyArgs_t args, Py_ssize_t i) {
     return args[i];
@@ -301,11 +154,7 @@ static inline CPyCppyy_PyArgs_t CPyCppyy_PyArgs_New(Py_ssize_t N) {
 static inline void CPyCppyy_PyArgs_DEL(CPyCppyy_PyArgs_t args) {
     PyMem_Free((void*)args);
 }
-#if PY_VERSION_HEX >= 0x03090000
 #define CPyCppyy_PyObject_Call  PyObject_Vectorcall
-#else
-#define CPyCppyy_PyObject_Call _PyObject_Vectorcall
-#endif
 inline PyObject* CPyCppyy_tp_call(
         PyObject* cb, CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds) {
     Py_ssize_t offset = Py_TYPE(cb)->tp_vectorcall_offset;
@@ -315,32 +164,6 @@ inline PyObject* CPyCppyy_tp_call(
 
 #ifndef Py_TPFLAGS_HAVE_VECTORCALL
 #define Py_TPFLAGS_HAVE_VECTORCALL _Py_TPFLAGS_HAVE_VECTORCALL
-#endif
-
-#else
-
-typedef PyObject* CPyCppyy_PyArgs_t;
-static inline PyObject* CPyCppyy_PyArgs_GET_ITEM(CPyCppyy_PyArgs_t args, Py_ssize_t i) {
-    return PyTuple_GET_ITEM(args, i);
-}
-static inline PyObject* CPyCppyy_PyArgs_SET_ITEM(CPyCppyy_PyArgs_t args, Py_ssize_t i, PyObject* item) {
-    return PyTuple_SET_ITEM(args, i, item);
-}
-static inline Py_ssize_t CPyCppyy_PyArgs_GET_SIZE(CPyCppyy_PyArgs_t args, size_t) {
-    return PyTuple_GET_SIZE(args);
-}
-static inline CPyCppyy_PyArgs_t CPyCppyy_PyArgs_New(Py_ssize_t N) {
-    return PyTuple_New(N);
-}
-static inline void CPyCppyy_PyArgs_DEL(CPyCppyy_PyArgs_t args) {
-    Py_DECREF(args);
-}
-inline PyObject* CPyCppyy_PyObject_Call(PyObject* cb, PyObject* args, size_t, PyObject* kwds) {
-    return PyObject_Call(cb, args, kwds);
-}
-inline PyObject* CPyCppyy_tp_call(PyObject* cb, PyObject* args, size_t, PyObject* kwds) {
-    return Py_TYPE(cb)->tp_call(cb, args, kwds);
-}
 #endif
 
 // weakref forced strong reference
@@ -358,24 +181,6 @@ static inline PyObject* CPyCppyy_GetWeakRef(PyObject* ref) {
     if (PyWeakref_GetRef(ref, &pyobject) != -1)
         return pyobject;
     return nullptr;
-}
-#endif
-
-// Py_TYPE as inline function
-#if PY_VERSION_HEX < 0x03090000 && !defined(Py_SET_TYPE)
-static inline
-void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type) { ob->ob_type = type; }
-#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
-#endif
-
-// py39 gained several faster (through vector call) equivalent method call API
-#if PY_VERSION_HEX < 0x03090000
-static inline PyObject* PyObject_CallMethodNoArgs(PyObject* obj, PyObject* name) {
-    return PyObject_CallMethodObjArgs(obj, name, nullptr);
-}
-
-static inline PyObject* PyObject_CallMethodOneArg(PyObject* obj, PyObject* name, PyObject* arg) {
-    return PyObject_CallMethodObjArgs(obj, name, arg, nullptr);
 }
 #endif
 

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -52,7 +52,6 @@ std::unordered_map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
 #if PY_VERSION_HEX < 0x030b0000
 
 //- from Python's dictobject.c -------------------------------------------------
-#if PY_VERSION_HEX >= 0x03030000
     typedef struct PyDictKeyEntry {
     /* Cached hash code of me_key. */
         Py_hash_t me_hash;
@@ -65,7 +64,6 @@ std::unordered_map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
         Py_ssize_t dk_size;
         dict_lookup_func dk_lookup;
         Py_ssize_t dk_usable;
-#if PY_VERSION_HEX >= 0x03060000
         Py_ssize_t dk_nentries;
         union {
             int8_t as_1[8];
@@ -75,20 +73,10 @@ std::unordered_map<Cppyy::TCppType_t, Cppyy::TCppType_t> TypeReductionMap;
             int64_t as_8[1];
 #endif
         } dk_indices;
-#else
-        PyDictKeyEntry dk_entries[1];
-#endif
     } PyDictKeysObject;
 
 #define CPYCPPYY_GET_DICT_LOOKUP(mp)                                          \
     ((dict_lookup_func&)mp->ma_keys->dk_lookup)
-
-#else
-
-#define CPYCPPYY_GET_DICT_LOOKUP(mp)                                          \
-    ((dict_lookup_func&)mp->ma_lookup)
-
-#endif
 
 #endif // PY_VERSION_HEX < 0x030b0000
 
@@ -110,40 +98,18 @@ static int nullptr_nonzero(PyObject*)
 
 static PyNumberMethods nullptr_as_number = {
     0, 0, 0,
-#if PY_VERSION_HEX < 0x03000000
-    0,
-#endif
     0, 0, 0, 0, 0, 0,
     (inquiry)nullptr_nonzero,           // tp_nonzero (nb_bool in p3)
     0, 0, 0, 0, 0, 0,
-#if PY_VERSION_HEX < 0x03000000
-    0,                                  // nb_coerce
-#endif
     0, 0, 0,
-#if PY_VERSION_HEX < 0x03000000
+    0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+    0,                                  // nb_floor_divide
+    0,                                  // nb_true_divide
     0, 0,
-#endif
-    0, 0, 0,
-#if PY_VERSION_HEX < 0x03000000
-    0,                                  // nb_inplace_divide
-#endif
-    0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02020000
-    , 0                                 // nb_floor_divide
-#if PY_VERSION_HEX < 0x03000000
-    , 0                                 // nb_true_divide
-#else
-    , 0                                 // nb_true_divide
-#endif
-    , 0, 0
-#endif
-#if PY_VERSION_HEX >= 0x02050000
-    , 0                                 // nb_index
-#endif
-#if PY_VERSION_HEX >= 0x03050000
-    , 0                                 // nb_matrix_multiply
-    , 0                                 // nb_inplace_matrix_multiply
-#endif
+    0,                                  // nb_index
+    0,                                  // nb_matrix_multiply
+    0                                   // nb_inplace_matrix_multiply
 };
 
 static PyTypeObject PyNullPtr_t_Type = {
@@ -162,19 +128,11 @@ static PyTypeObject PyNullPtr_t_Type = {
     (hashfunc)_Py_HashPointer, // tp_hash
 #endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                  // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                  // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                  // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                  // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                   // tp_del
+    0,                   // tp_version_tag
+    0,                   // tp_finalize
+    0                    // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -204,19 +162,11 @@ static PyTypeObject PyDefault_t_Type = {
     (hashfunc)_Py_HashPointer, // tp_hash
 #endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                  // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                  // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                  // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                 // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                  // tp_del
+    0,                  // tp_version_tag
+    0,                  // tp_finalize
+    0                   // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -286,7 +236,6 @@ private:
 
 } // unnamed namespace
 
-#if PY_VERSION_HEX >= 0x03060000
 inline Py_ssize_t OrgDictLookup(PyDictObject* mp, PyObject* key,
     Py_hash_t hash, PyObject*** value_addr, Py_ssize_t* hashpos)
 {
@@ -297,50 +246,16 @@ inline Py_ssize_t OrgDictLookup(PyDictObject* mp, PyObject* key,
 
 Py_ssize_t CPyCppyyLookDictString(PyDictObject* mp, PyObject* key,
     Py_hash_t hash, PyObject*** value_addr, Py_ssize_t* hashpos)
-
-#elif PY_VERSION_HEX >= 0x03030000
-inline PyDictKeyEntry* OrgDictLookup(
-    PyDictObject* mp, PyObject* key, Py_hash_t hash, PyObject*** value_addr)
-{
-    return (*gDictLookupOrg)(mp, key, hash, value_addr);
-}
-
-#define CPYCPPYY_ORGDICT_LOOKUP(mp, key, hash, value_addr, hashpos)           \
-    OrgDictLookup(mp, key, hash, value_addr)
-
-PyDictKeyEntry* CPyCppyyLookDictString(
-    PyDictObject* mp, PyObject* key, Py_hash_t hash, PyObject*** value_addr)
-
-#else /* < 3.3 */
-
-inline PyDictEntry* OrgDictLookup(PyDictObject* mp, PyObject* key, long hash)
-{
-    return (*gDictLookupOrg)(mp, key, hash);
-}
-
-#define CPYCPPYY_ORGDICT_LOOKUP(mp, key, hash, value_addr, hashpos)           \
-    OrgDictLookup(mp, key, hash)
-
-PyDictEntry* CPyCppyyLookDictString(PyDictObject* mp, PyObject* key, long hash)
-#endif
 {
     static GblGetter gbl;
-#if PY_VERSION_HEX >= 0x03060000
     Py_ssize_t ep;
-#else
-    PyDictEntry* ep;
-#endif
 
 // first search dictionary itself
     ep = CPYCPPYY_ORGDICT_LOOKUP(mp, key, hash, value_addr, hashpos);
     if (gDictLookupActive)
         return ep;
 
-#if PY_VERSION_HEX >= 0x03060000
     if (ep >= 0)
-#else
-    if (!ep || (ep->me_key && ep->me_value))
-#endif
         return ep;
 
 // filter for builtins
@@ -371,12 +286,7 @@ PyDictEntry* CPyCppyyLookDictString(PyDictObject* mp, PyObject* key, long hash)
         if (PyDict_SetItem((PyObject*)mp, key, val) == 0) {
             ep = CPYCPPYY_ORGDICT_LOOKUP(mp, key, hash, value_addr, hashpos);
         } else {
-#if PY_VERSION_HEX >= 0x03060000
             ep = -1;
-#else
-            ep->me_key   = nullptr;
-            ep->me_value = nullptr;
-#endif
         }
         CPYCPPYY_GET_DICT_LOOKUP(mp) = CPyCppyyLookDictString;   // restore
 
@@ -385,7 +295,6 @@ PyDictEntry* CPyCppyyLookDictString(PyDictObject* mp, PyObject* key, long hash)
     } else
         PyErr_Clear();
 
-#if PY_VERSION_HEX >= 0x03030000
     if (mp->ma_keys->dk_usable <= 0) {
     // big risk that this lookup will result in a resize, so force it here
     // to be able to reset the lookup function; of course, this is nowhere
@@ -413,7 +322,6 @@ PyDictEntry* CPyCppyyLookDictString(PyDictObject* mp, PyObject* key, long hash)
         gDictLookupOrg = CPYCPPYY_GET_DICT_LOOKUP(mp);
         CPYCPPYY_GET_DICT_LOOKUP(mp) = CPyCppyyLookDictString;   // restore
     }
-#endif
 
 // stopped calling into the reflection system
     gDictLookupActive = false;
@@ -614,11 +522,7 @@ static PyObject* AsCapsule(PyObject* /* unused */, PyObject* args, PyObject* kwd
 // Return object proxy as an opaque PyCapsule.
     void* addr = GetCPPInstanceAddress("as_capsule", args, kwds);
     if (addr)
-#if PY_VERSION_HEX < 0x02060000
-        return PyCObject_FromVoidPtr(addr, nullptr);
-#else
         return PyCapsule_New(addr, nullptr, nullptr);
-#endif
     return nullptr;
 }
 
@@ -1059,7 +963,6 @@ static PyMethodDef gCPyCppyyMethods[] = {
 };
 
 
-#if PY_VERSION_HEX >= 0x03000000
 struct module_state {
     PyObject *error;
 };
@@ -1091,8 +994,6 @@ static struct PyModuleDef moduledef = {
     nullptr
 };
 
-#endif
-
 namespace CPyCppyy {
 
 //----------------------------------------------------------------------------
@@ -1105,9 +1006,6 @@ extern "C" PyObject* PyInit_libcppyy()
         return nullptr;
 
 // setup interpreter
-#if PY_VERSION_HEX < 0x03090000
-    PyEval_InitThreads();
-#endif
 
 #if PY_VERSION_HEX < 0x030b0000
 // prepare for laziness (the insert is needed to capture the most generic lookup
@@ -1116,20 +1014,12 @@ extern "C" PyObject* PyInit_libcppyy()
     PyObject* notstring = PyInt_FromLong(5);
     PyDict_SetItem(dict, notstring, notstring);
     Py_DECREF(notstring);
-#if PY_VERSION_HEX >= 0x03030000
     gDictLookupOrg = (dict_lookup_func)((PyDictObject*)dict)->ma_keys->dk_lookup;
-#else
-    gDictLookupOrg = (dict_lookup_func)((PyDictObject*)dict)->ma_lookup;
-#endif
     Py_DECREF(dict);
 #endif // PY_VERSION_HEX < 0x030b0000
 
 // setup this module
-#if PY_VERSION_HEX >= 0x03000000
     gThisModule = PyModule_Create(&moduledef);
-#else
-    gThisModule = Py_InitModule(const_cast<char*>("libcppyy"), gCPyCppyyMethods);
-#endif
     if (!gThisModule)
         return nullptr;
 
@@ -1166,15 +1056,6 @@ extern "C" PyObject* PyInit_libcppyy()
 // inject property proxy type
     if (!Utility::InitProxy(gThisModule, &CPPDataMember_Type, "CPPDataMember"))
         return nullptr;
-
-// inject custom data types
-#if PY_VERSION_HEX < 0x03000000
-    if (!Utility::InitProxy(gThisModule, &RefFloat_Type, "Double"))
-        return nullptr;
-
-    if (!Utility::InitProxy(gThisModule, &RefInt_Type, "Long"))
-        return nullptr;
-#endif
 
     if (!Utility::InitProxy(gThisModule, &CustomInstanceMethod_Type, "InstanceMethod"))
         return nullptr;

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -34,21 +34,6 @@
 #include <span>
 #endif
 
-// codecvt does not exist for gcc4.8.5 and is in principle deprecated; it is
-// only used in py2 for char -> wchar_t conversion for std::wstring; if not
-// available, the conversion is done through Python (requires an extra copy)
-#if PY_VERSION_HEX < 0x03000000
-#if defined(__GNUC__) && !defined(__APPLE__)
-# if __GNUC__ > 4 && __has_include("codecvt")
-# include <codecvt>
-# define HAS_CODECVT 1
-# endif
-#else
-#include <codecvt>
-#define HAS_CODECVT 1
-#endif
-#endif // py2
-
 
 //- data _____________________________________________________________________
 namespace CPyCppyy {
@@ -68,18 +53,7 @@ namespace CPyCppyy {
 // Define our own PyUnstable_Object_IsUniqueReferencedTemporary function if the
 // Python version is lower than 3.14, the version where that function got introduced.
 #if PY_VERSION_HEX < 0x030e0000
-#if PY_VERSION_HEX < 0x03000000
 const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 1;
-#elif PY_VERSION_HEX < 0x03080000
-// p3 has at least 2 ref-counts, as contrary to p2, it will create a descriptor
-// copy for the method holding self in the case of __init__; but there can also
-// be a reference held by the frame object, which is indistinguishable from a
-// local variable reference, so the cut-off has to remain 2.
-const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 2;
-#else
-// since py3.8, vector calls behave again as expected
-const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 1;
-#endif
 inline bool PyUnstable_Object_IsUniqueReferencedTemporary(PyObject *pyobject) {
     return Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF;
 }
@@ -791,13 +765,6 @@ bool CPyCppyy::LongRefConverter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ long&, set arg for call
-#if PY_VERSION_HEX < 0x03000000
-    if (RefInt_CheckExact(pyobject)) {
-        para.fValue.fVoidp = (void*)&((PyIntObject*)pyobject)->ob_ival;
-        para.fTypeCode = 'V';
-        return true;
-    }
-#endif
 
     if (Py_TYPE(pyobject) == GetCTypesType(ct_c_long)) {
         para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;
@@ -835,21 +802,12 @@ bool CPyCppyy::IntRefConverter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ (pseudo)int&, set arg for call
-#if PY_VERSION_HEX < 0x03000000
-    if (RefInt_CheckExact(pyobject)) {
-        para.fValue.fVoidp = (void*)&((PyIntObject*)pyobject)->ob_ival;
-        para.fTypeCode = 'V';
-        return true;
-    }
-#endif
 
-#if PY_VERSION_HEX >= 0x02050000
     if (Py_TYPE(pyobject) == GetCTypesType(ct_c_int)) {
         para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;
         para.fTypeCode = 'V';
         return true;
     }
-#endif
 
 // alternate, pass pointer from buffer
     Py_ssize_t buflen = Utility::GetBuffer(pyobject, 'i', sizeof(int), para.fValue.fVoidp);
@@ -858,11 +816,7 @@ bool CPyCppyy::IntRefConverter::SetArg(
         return true;
     };
 
-#if PY_VERSION_HEX < 0x02050000
-    PyErr_SetString(PyExc_TypeError, "use cppyy.Long for pass-by-ref of ints");
-#else
     PyErr_SetString(PyExc_TypeError, "use ctypes.c_int for pass-by-ref of ints");
-#endif
     return false;
 }
 
@@ -1171,21 +1125,12 @@ bool CPyCppyy::DoubleRefConverter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ double&, set arg for call
-#if PY_VERSION_HEX < 0x03000000
-    if (RefFloat_CheckExact(pyobject)) {
-        para.fValue.fVoidp = (void*)&((PyFloatObject*)pyobject)->ob_fval;
-        para.fTypeCode = 'V';
-        return true;
-    }
-#endif
 
-#if PY_VERSION_HEX >= 0x02050000
     if (Py_TYPE(pyobject) == GetCTypesType(ct_c_double)) {
         para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;
         para.fTypeCode = 'V';
         return true;
     }
-#endif
 
 // alternate, pass pointer from buffer
     Py_ssize_t buflen = Utility::GetBuffer(pyobject, 'd', sizeof(double), para.fValue.fVoidp);
@@ -1194,11 +1139,7 @@ bool CPyCppyy::DoubleRefConverter::SetArg(
         return true;
     }
 
-#if PY_VERSION_HEX < 0x02050000
-    PyErr_SetString(PyExc_TypeError, "use cppyy.Double for pass-by-ref of doubles");
-#else
     PyErr_SetString(PyExc_TypeError, "use ctypes.c_double for pass-by-ref of doubles");
-#endif
     return false;
 }
 
@@ -1895,9 +1836,7 @@ bool CPyCppyy::CStringArrayConverter::SetArg(
         return true;
 
     } else if (PySequence_Check(pyobject) && !CPyCppyy_PyText_Check(pyobject)
-#if PY_VERSION_HEX >= 0x03000000
         && !PyBytes_Check(pyobject)
-#endif
     ) {
         //for (auto& p : fBuffer) free(p);
         fBuffer.clear();
@@ -1976,12 +1915,7 @@ static inline bool CPyCppyy_PyUnicodeAsBytes2Buffer(PyObject* pyobject, T& buffe
         Py_INCREF(pyobject);
         pybytes = pyobject;
     } else if (PyUnicode_Check(pyobject)) {
-#if PY_VERSION_HEX < 0x03030000
-        pybytes = PyUnicode_EncodeUTF8(
-            PyUnicode_AS_UNICODE(pyobject), CPyCppyy_PyUnicode_GET_SIZE(pyobject), nullptr);
-#else
         pybytes = PyUnicode_AsUTF8String(pyobject);
-#endif
     }
 
     if (pybytes) {
@@ -2052,23 +1986,6 @@ bool CPyCppyy::STLWStringConverter::SetArg(
         para.fTypeCode = 'V';
         return true;
     }
-#if PY_VERSION_HEX < 0x03000000
-    else if (PyString_Check(pyobject)) {
-#ifdef HAS_CODECVT
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> cnv;
-        fBuffer = cnv.from_bytes(PyString_AS_STRING(pyobject));
-#else
-        PyObject* pyu = PyUnicode_FromString(PyString_AS_STRING(pyobject));
-        if (!pyu) return false;
-        Py_ssize_t len = CPyCppyy_PyUnicode_GET_SIZE(pyu);
-        fBuffer.resize(len);
-        CPyCppyy_PyUnicode_AsWideChar(pyu, &fBuffer[0], len);
-#endif
-        para.fValue.fVoidp = &fBuffer;
-        para.fTypeCode = 'V';
-        return true;
-    }
-#endif
 
     if (!(PyInt_Check(pyobject) || PyLong_Check(pyobject))) {
         bool result = InstancePtrConverter<false>::SetArg(pyobject, para, ctxt);
@@ -2338,11 +2255,7 @@ bool CPyCppyy::InstanceConverter::ToMemory(PyObject* value, void* address, PyObj
 {
 // assign value to C++ instance living at <address> through assignment operator
     PyObject* pyobj = BindCppObjectNoCast(address, fClass);
-#if PY_VERSION_HEX >= 0x03080000
     PyObject* result = PyObject_CallMethodOneArg(pyobj, PyStrings::gAssign, value);
-#else
-    PyObject* result = PyObject_CallMethod(pyobj, (char*)"__assign__", (char*)"O", value);
-#endif
     Py_DECREF(pyobj);
 
     if (result) {
@@ -3086,11 +2999,7 @@ bool CPyCppyy::SmartPtrConverter::ToMemory(PyObject* value, void* address, PyObj
 // assign value to C++ instance living at <address> through assignment operator (this
 // is similar to InstanceConverter::ToMemory, but prevents wrapping the smart ptr)
     PyObject* pyobj = BindCppObjectNoCast(address, fSmartPtrType, CPPInstance::kNoWrapConv);
-#if PY_VERSION_HEX >= 0x03080000
     PyObject* result = PyObject_CallMethodOneArg(pyobj, PyStrings::gAssign, value);
-#else
-    PyObject* result = PyObject_CallMethod(pyobj, (char*)"__assign__", (char*)"O", value);
-#endif
     Py_DECREF(pyobj);
 
     if (result) {
@@ -3171,12 +3080,7 @@ bool CPyCppyy::InitializerListConverter::SetArg(
 // convert the given argument to an initializer list temporary; this is purely meant
 // to be a syntactic thing, so only _python_ sequences are allowed; bound C++ proxies
 // (likely explicitly created std::initializer_list, go through an instance converter
-    if (!PySequence_Check(pyobject) || CPyCppyy_PyText_Check(pyobject)
-#if PY_VERSION_HEX >= 0x03000000
-        || PyBytes_Check(pyobject)
-#else
-        || PyUnicode_Check(pyobject)
-#endif
+    if (!PySequence_Check(pyobject) || CPyCppyy_PyText_Check(pyobject) || PyBytes_Check(pyobject)
         )
         return false;
 

--- a/src/CustomPyTypes.cxx
+++ b/src/CustomPyTypes.cxx
@@ -13,64 +13,10 @@
 // same, because the actual C++ type of the PyObject is PyMethodObject anyway.
 #define CustomInstanceMethod_GET_SELF(meth) reinterpret_cast<PyMethodObject *>(meth)->im_self
 #define CustomInstanceMethod_GET_FUNCTION(meth) reinterpret_cast<PyMethodObject *>(meth)->im_func
-#if PY_VERSION_HEX >= 0x03000000
 // TODO: this will break functionality
 #define CustomInstanceMethod_GET_CLASS(meth) Py_None
-#else
-#define CustomInstanceMethod_GET_CLASS(meth) PyMethod_GET_CLASS(meth)
-#endif
 
 namespace CPyCppyy {
-
-#if PY_VERSION_HEX < 0x03000000
-//= float type allowed for reference passing =================================
-PyTypeObject RefFloat_Type = {     // python float is a C/C++ double
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    (char*)"cppyy.Double",         // tp_name
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES |
-        Py_TPFLAGS_BASETYPE,       // tp_flags
-    (char*)"CPyCppyy float object for pass by reference",   // tp_doc
-    0, 0, 0, 0, 0, 0, 0, 0, 0,
-    &PyFloat_Type,                 // tp_base
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-};
-
-//= long type allowed for reference passing ==================================
-PyTypeObject RefInt_Type = {       // python int is a C/C++ long
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    (char*)"cppyy.Long",           // tp_name
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES |
-        Py_TPFLAGS_BASETYPE
-#if PY_VERSION_HEX >= 0x03040000
-        | Py_TPFLAGS_LONG_SUBCLASS
-#endif
-        ,                          // tp_flags
-    (char*)"CPyCppyy long object for pass by reference",    // tp_doc
-    0, 0, 0, 0, 0, 0, 0, 0, 0,
-    &PyInt_Type,                   // tp_base
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-};
-#endif
 
 //- custom type representing typedef to pointer of class ---------------------
 static PyObject* tptc_call(typedefpointertoclassobject* self, PyObject* args, PyObject* /* kwds */)
@@ -154,19 +100,11 @@ PyTypeObject TypedefPointerToClass_Type = {
     0,                              // tp_mro
     0,                              // tp_cache
     0,                              // tp_subclasses
-    0                               // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                           // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                           // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                           // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0,                              // tp_weaklist
+    0,                              // tp_del
+    0,                              // tp_version_tag
+    0,                              // tp_finalize
+    0                               // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -178,11 +116,7 @@ static int numfree = 0;
 #endif
 
 //-----------------------------------------------------------------------------
-PyObject* CustomInstanceMethod_New(PyObject* func, PyObject* self, PyObject*
-#if PY_VERSION_HEX < 0x03000000
-        pyclass
-#endif
-    )
+PyObject* CustomInstanceMethod_New(PyObject* func, PyObject* self, PyObject*)
 {
 // from instancemethod, but with custom type (at issue is that instancemethod is not
 // meant to be derived from)
@@ -209,10 +143,6 @@ PyObject* CustomInstanceMethod_New(PyObject* func, PyObject* self, PyObject*
     im->im_func = func;
     Py_XINCREF(self);
     im->im_self = self;
-#if PY_VERSION_HEX < 0x03000000
-    Py_XINCREF(pyclass);
-    im->im_class = pyclass;
-#endif
     PyObject_GC_Track(im);
     return (PyObject*)im;
 }
@@ -229,9 +159,6 @@ static void im_dealloc(PyMethodObject* im)
 
     Py_DECREF(im->im_func);
     Py_XDECREF(im->im_self);
-#if PY_VERSION_HEX < 0x03000000
-    Py_XDECREF(im->im_class);
-#endif
 
     if (numfree < PyMethod_MAXFREELIST) {
         im->im_self = (PyObject*)free_list;
@@ -291,12 +218,7 @@ static PyObject* im_descr_get(PyObject* meth, PyObject* obj, PyObject* pyclass)
 {
 // from instancemethod: don't rebind an already bound method, or an unbound method
 // of a class that's not a base class of pyclass
-    if (CustomInstanceMethod_GET_SELF(meth)
-#if PY_VERSION_HEX < 0x03000000
-         || (CustomInstanceMethod_GET_CLASS(meth) &&
-             !PyObject_IsSubclass(pyclass, CustomInstanceMethod_GET_CLASS(meth)))
-#endif
-            ) {
+    if (CustomInstanceMethod_GET_SELF(meth)) {
         Py_INCREF(meth);
         return meth;
     }
@@ -323,19 +245,11 @@ PyTypeObject CustomInstanceMethod_Type = {
     &PyMethod_Type,                // tp_base
     0,
     im_descr_get,                  // tp_descr_get
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -378,19 +292,11 @@ PyTypeObject IndexIter_Type = {
     0, 0, 0,
     PyObject_SelfIter,            // tp_iter
     (iternextfunc)indexiter_iternext,  // tp_iternext
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                           // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                           // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                           // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                            // tp_del
+    0,                            // tp_version_tag
+    0,                            // tp_finalize
+    0                             // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -444,19 +350,11 @@ PyTypeObject VectorIter_Type = {
     0, 0, 0,
     PyObject_SelfIter,            // tp_iter
     (iternextfunc)vectoriter_iternext,      // tp_iternext
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                           // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                           // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                           // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                            // tp_del
+    0,                            // tp_version_tag
+    0,                            // tp_finalize
+    0                             // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/CustomPyTypes.h
+++ b/src/CustomPyTypes.h
@@ -10,38 +10,6 @@ namespace CPyCppyy {
     performance.
  */
 
-#if PY_VERSION_HEX < 0x03000000
-//- reference float object type and type verification ------------------------
-extern PyTypeObject RefFloat_Type;
-
-template<typename T>
-inline bool RefFloat_Check(T* object)
-{
-    return object && PyObject_TypeCheck(object, &RefFloat_Type);
-}
-
-template<typename T>
-inline bool RefFloat_CheckExact(T* object)
-{
-    return object && Py_TYPE(object) == &RefFloat_Type;
-}
-
-//- reference long object type and type verification -------------------------
-extern PyTypeObject RefInt_Type;
-
-template<typename T>
-inline bool RefInt_Check(T* object)
-{
-    return object && PyObject_TypeCheck(object, &RefInt_Type);
-}
-
-template<typename T>
-inline bool RefInt_CheckExact(T* object)
-{
-    return object && Py_TYPE(object) == &RefInt_Type;
-}
-#endif
-
 //- custom type representing typedef to pointer of class ---------------------
 struct typedefpointertoclassobject {
     PyObject_HEAD

--- a/src/Dispatcher.cxx
+++ b/src/Dispatcher.cxx
@@ -60,11 +60,7 @@ static inline void InjectMethod(Cppyy::TCppMethod_t method, const std::string& m
     Utility::ConstructCallbackPreamble(retType, argtypes, code);
 
 // perform actual method call
-#if PY_VERSION_HEX < 0x03000000
-    code << "    PyObject* mtPyName = PyString_FromString(\"" << mtCppName << "\");\n" // TODO: intern?
-#else
     code << "    PyObject* mtPyName = PyUnicode_FromString(\"" << mtCppName << "\");\n"
-#endif
             "    PyObject* pyresult = PyObject_CallMethodObjArgs(iself, mtPyName";
     for (Cppyy::TCppIndex_t i = 0; i < nArgs; ++i)
         code << ", pyargs[" << i << "]";

--- a/src/LowLevelViews.cxx
+++ b/src/LowLevelViews.cxx
@@ -323,11 +323,7 @@ static inline int init_slice(Py_buffer* base, PyObject* _key, int dim)
 {
     Py_ssize_t start, stop, step, slicelength;
 
-#if PY_VERSION_HEX < 0x03000000
-    PySliceObject* key = (PySliceObject*)_key;
-#else
     PyObject* key = _key;
-#endif
 
     if (PySlice_GetIndicesEx(key, base->shape[dim], &start, &stop, &step, &slicelength) < 0)
         return -1;
@@ -610,27 +606,6 @@ static int ll_ass_sub(CPyCppyy::LowLevelView* self, PyObject* key, PyObject* val
     return -1;
 }
 
-#if PY_VERSION_HEX < 0x03000000
-//---------------------------------------------------------------------------
-static Py_ssize_t ll_oldgetbuf(CPyCppyy::LowLevelView* self, Py_ssize_t seg, void** pptr)
-{
-    if (seg != 0) {
-        PyErr_SetString(PyExc_TypeError, "accessing non-existent segment");
-        return -1;
-    }
-
-    *pptr = self->get_buf();
-    return self->fBufInfo.len;
-}
-
-//---------------------------------------------------------------------------
-static Py_ssize_t ll_getsegcount(PyObject*, Py_ssize_t* lenp)
-{
-    if (lenp) *lenp = 1;
-    return 1;
-}
-#endif
-
 //---------------------------------------------------------------------------
 static int ll_getbuf(CPyCppyy::LowLevelView* self, Py_buffer* view, int flags)
 {
@@ -721,12 +696,6 @@ static PySequenceMethods ll_as_sequence = {
 
 //- buffer methods ----------------------------------------------------------
 static PyBufferProcs ll_as_buffer = {
-#if PY_VERSION_HEX < 0x03000000
-    (readbufferproc)ll_oldgetbuf,   // bf_getreadbuffer
-    (writebufferproc)ll_oldgetbuf,  // bf_getwritebuffer
-    (segcountproc)ll_getsegcount,   // bf_getsegcount
-    0,                              // bf_getcharbuffer
-#endif
     (getbufferproc)ll_getbuf,       // bf_getbuffer
     0,                              // bf_releasebuffer
 };
@@ -967,19 +936,11 @@ PyTypeObject LowLevelView_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                            // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/MemoryRegulator.cxx
+++ b/src/MemoryRegulator.cxx
@@ -36,18 +36,6 @@ static PyMappingMethods CPyCppyy_NoneType_mapping = {
 //-----------------------------------------------------------------------------
 namespace {
 
-// Py_SET_REFCNT was only introduced in Python 3.9
-#if PY_VERSION_HEX < 0x03090000
-inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
-    assert(refcnt >= 0);
-#if SIZEOF_VOID_P > 4
-    ob->ob_refcnt = (PY_UINT32_T)refcnt;
-#else
-    ob->ob_refcnt = refcnt;
-#endif
-}
-#endif
-
 struct InitCPyCppyy_NoneType_t {
     InitCPyCppyy_NoneType_t() {
     // create a CPyCppyy NoneType (for references that went dodo) from NoneType
@@ -65,10 +53,6 @@ struct InitCPyCppyy_NoneType_t {
         CPyCppyy_NoneType.tp_dealloc     = (destructor)&InitCPyCppyy_NoneType_t::DeAlloc;
         CPyCppyy_NoneType.tp_repr        = Py_TYPE(Py_None)->tp_repr;
         CPyCppyy_NoneType.tp_richcompare = (richcmpfunc)&InitCPyCppyy_NoneType_t::RichCompare;
-#if PY_VERSION_HEX < 0x03000000
-    // tp_compare has become tp_reserved (place holder only) in p3
-        CPyCppyy_NoneType.tp_compare     = (cmpfunc)&InitCPyCppyy_NoneType_t::Compare;
-#endif
         CPyCppyy_NoneType.tp_hash        = (hashfunc)&InitCPyCppyy_NoneType_t::PtrHash;
 
         CPyCppyy_NoneType.tp_as_mapping  = &CPyCppyy_NoneType_mapping;
@@ -84,12 +68,8 @@ struct InitCPyCppyy_NoneType_t {
     }
 
     static int Compare(PyObject*, PyObject* other) {
-#if PY_VERSION_HEX < 0x03000000
-        return PyObject_Compare(other, Py_None);
-#else
     // TODO the following isn't correct as it doesn't order, but will do for now ...
         return !PyObject_RichCompareBool(other, Py_None, Py_EQ);
-#endif
     }
 };
 

--- a/src/PyObjectDir27.inc
+++ b/src/PyObjectDir27.inc
@@ -111,57 +111,6 @@ static int merge_class_dict(PyObject* dict, PyObject* aclass)
     return 0;
 }
 
-#if PY_VERSION_HEX < 0x03000000
-
-/* Helper for PyObject_Dir.
-   If obj has an attr named attrname that's a list, merge its string
-   elements into keys of dict.
-   Return 0 on success, -1 on error.  Errors due to not finding the attr,
-   or the attr not being a list, are suppressed.
-*/
-
-static int
-merge_list_attr(PyObject* dict, PyObject* obj, const char *attrname)
-{
-    PyObject *list;
-    int result = 0;
-
-    assert(PyDict_Check(dict));
-    assert(obj);
-    assert(attrname);
-
-    list = PyObject_GetAttrString(obj, attrname);
-    if (list == NULL)
-        PyErr_Clear();
-
-    else if (PyList_Check(list)) {
-        int i;
-        for (i = 0; i < PyList_GET_SIZE(list); ++i) {
-            PyObject *item = PyList_GET_ITEM(list, i);
-            if (PyString_Check(item)) {
-                result = PyDict_SetItem(dict, item, Py_None);
-                if (result < 0)
-                    break;
-            }
-        }
-        if (Py_Py3kWarningFlag &&
-            (strcmp(attrname, "__members__") == 0 ||
-             strcmp(attrname, "__methods__") == 0)) {
-            if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                           "__members__ and __methods__ not "
-                           "supported in 3.x", 1) < 0) {
-                Py_XDECREF(list);
-                return -1;
-            }
-        }
-    }
-
-    Py_XDECREF(list);
-    return result;
-}
-
-#endif
-
 /* Helper for PyObject_Dir of type objects: returns __dict__ and __bases__.
    We deliberately don't suck up its __class__, as methods belonging to the
    metaclass would probably be more confusing than helpful.
@@ -207,15 +156,6 @@ static PyObject* _generic_dir(PyObject *obj)
 
     if (dict == NULL)
         goto error;
-
-#if PY_VERSION_HEX < 0x03000000
-    /* Merge in __members__ and __methods__ (if any).
-     * This is removed in Python 3000. */
-    if (merge_list_attr(dict, obj, "__members__") < 0)
-        goto error;
-    if (merge_list_attr(dict, obj, "__methods__") < 0)
-        goto error;
-#endif
 
     /* Merge in attrs reachable from its class. */
     itsclass = PyObject_GetAttrString(obj, "__class__");

--- a/src/PyStrings.cxx
+++ b/src/PyStrings.cxx
@@ -92,11 +92,7 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gBase,           __base__);
     CPPYY_INITIALIZE_STRING(gContains,       contains);
     CPPYY_INITIALIZE_STRING(gCopy,           copy);
-#if PY_VERSION_HEX < 0x03000000
-    CPPYY_INITIALIZE_STRING(gCppBool,        __cpp_nonzero__);
-#else
     CPPYY_INITIALIZE_STRING(gCppBool,        __cpp_bool__);
-#endif
     CPPYY_INITIALIZE_STRING(gCppName,        __cpp_name__);
     CPPYY_INITIALIZE_STRING(gAnnotations,    __annotations__);
     CPPYY_INITIALIZE_STRING(gCastCpp,        __cast_cpp__);

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -214,9 +214,6 @@ PyObject* NullCheckBool(PyObject* self)
 }
 
 //- vector behavior as primitives ----------------------------------------------
-#if PY_VERSION_HEX < 0x03040000
-#define PyObject_LengthHint _PyObject_LengthHint
-#endif
 
 // TODO: can probably use the below getters in the InitializerListConverter
 struct ItemGetter {
@@ -850,13 +847,8 @@ PyObject* MapInit(PyObject* self, PyObject* args, PyObject* /* kwds */)
     if (PyTuple_GET_SIZE(args) == 1 && PyMapping_Check(PyTuple_GET_ITEM(args, 0)) && \
            !(PyTuple_Check(PyTuple_GET_ITEM(args, 0)) || PyList_Check(PyTuple_GET_ITEM(args, 0)))) {
         PyObject* assoc = PyTuple_GET_ITEM(args, 0);
-#if PY_VERSION_HEX < 0x03000000
-    // to prevent warning about literal string, expand macro
-        PyObject* items = PyObject_CallMethod(assoc, (char*)"items", nullptr);
-#else
     // in p3, PyMapping_Items isn't a macro, but a function that short-circuits dict
         PyObject* items = PyMapping_Items(assoc);
-#endif
         if (items && PySequence_Check(items)) {
             PyObject* result = MapFromPairs(self, items);
             Py_DECREF(items);
@@ -1115,12 +1107,10 @@ PyObject* SmartPtrInit(PyObject* self, PyObject* args, PyObject* /* kwds */)
 
 
 //- string behavior as primitives --------------------------------------------
-#if PY_VERSION_HEX >= 0x03000000
 // TODO: this is wrong, b/c it doesn't order
 static int PyObject_Compare(PyObject* one, PyObject* other) {
     return !PyObject_RichCompareBool(one, other, Py_EQ);
 }
-#endif
 static inline
 PyObject* CPyCppyy_PyString_FromCppString(std::string_view s, bool native=true) {
     if (native)
@@ -1624,11 +1614,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, Cppyy::TCppScope_t scope)
 
 // for pre-check of nullptr for boolean types
     if (HasAttrDirect(pyclass, PyStrings::gCppBool)) {
-#if PY_VERSION_HEX >= 0x03000000
         const char* pybool_name = "__bool__";
-#else
-        const char* pybool_name = "__nonzero__";
-#endif
         Utility::AddToClass(pyclass, pybool_name, (PyCFunction)NullCheckBool, METH_NOARGS);
     }
 

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -82,7 +82,6 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
 // Instantiate (and cache) templated methods, return method if any
     std::string proto = "";
 
-#if PY_VERSION_HEX >= 0x03080000
 // adjust arguments for self if this is a rebound global function
     bool isNS = (((CPPScope*)fTI->fPyClass)->fFlags & CPPScope::kIsNamespace);
     if (!isNS && CPyCppyy_PyArgs_GET_SIZE(args, nargsf) && \
@@ -91,7 +90,6 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
         args   += 1;
         nargsf -= 1;
     }
-#endif
 
     Py_ssize_t argc = CPyCppyy_PyArgs_GET_SIZE(args, nargsf);
     if (argc != 0) {
@@ -164,17 +162,12 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
             }
         }
 
-#if PY_VERSION_HEX >= 0x03080000
         PyObject* pyargs = PyTuple_New(argc);
         for (Py_ssize_t i = 0; i < argc; ++i) {
             PyObject* item = CPyCppyy_PyArgs_GET_ITEM(args, i);
             Py_INCREF(item);
             PyTuple_SET_ITEM(pyargs, i, item);
         }
-#else
-        Py_INCREF(args);
-        PyObject* pyargs = args;
-#endif
         const std::string& name_v1 = \
             Utility::ConstructTemplateArgs(nullptr, tpArgs, pyargs, pref, 0, pcnt);
 
@@ -514,12 +507,8 @@ static inline PyObject* CallMethodImp(TemplateProxy* pytmpl, PyObject*& pymeth,
     return result;
 }
 
-#if PY_VERSION_HEX >= 0x03080000
 static PyObject* tpp_vectorcall(
     TemplateProxy* pytmpl, PyObject* const *args, size_t nargsf, PyObject* kwds)
-#else
-static PyObject* tpp_call(TemplateProxy* pytmpl, PyObject* args, PyObject* kwds)
-#endif
 {
 // Dispatcher to the actual member method, several uses possible; in order:
 //
@@ -548,10 +537,6 @@ static PyObject* tpp_call(TemplateProxy* pytmpl, PyObject* args, PyObject* kwds)
 //
 
 // TODO: should previously instantiated templates be considered first?
-
-#if PY_VERSION_HEX < 0x03080000
-    size_t nargsf = PyTuple_GET_SIZE(args);
-#endif
 
     PyObject *pymeth = nullptr, *result = nullptr;
 
@@ -710,9 +695,7 @@ static TemplateProxy* tpp_descr_get(TemplateProxy* pytmpl, PyObject* pyobj, PyOb
 // copy name, class, etc. pointers
     new (&newPyTmpl->fTI) std::shared_ptr<TemplateInfo>{pytmpl->fTI};
 
-#if PY_VERSION_HEX >= 0x03080000
     newPyTmpl->fVectorCall = pytmpl->fVectorCall;
-#endif
 
     return newPyTmpl;
 }
@@ -778,9 +761,7 @@ void TemplateProxy::Set(const std::string& cppname, const std::string& pyname, P
     fTI->fTemplated    = CPPOverload_New(pyname, dummy);
     fTI->fLowPriority  = CPPOverload_New(pyname, dummy);
 
-#if PY_VERSION_HEX >= 0x03080000
     fVectorCall = (vectorcallfunc)tpp_vectorcall;
-#endif
 }
 
 
@@ -891,11 +872,7 @@ PyTypeObject TemplateProxy_Type = {
     sizeof(TemplateProxy),             // tp_basicsize
     0,                                 // tp_itemsize
     (destructor)tpp_dealloc,           // tp_dealloc
-#if PY_VERSION_HEX >= 0x03080000
     offsetof(TemplateProxy, fVectorCall),
-#else
-    0,                                 // tp_vectorcall_offset / tp_print
-#endif
     0,                                 // tp_getattr
     0,                                 // tp_setattr
     0,                                 // tp_as_async / tp_compare
@@ -904,20 +881,13 @@ PyTypeObject TemplateProxy_Type = {
     0,                                 // tp_as_sequence
     &tpp_as_mapping,                   // tp_as_mapping
     (hashfunc)tpp_hash,                // tp_hash
-#if PY_VERSION_HEX >= 0x03080000
     (ternaryfunc)PyVectorcall_Call,    // tp_call
-#else
-    (ternaryfunc)tpp_call,             // tp_call
-#endif
     0,                                 // tp_str
     0,                                 // tp_getattro
     0,                                 // tp_setattro
     0,                                 // tp_as_buffer
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC
-#if PY_VERSION_HEX >= 0x03080000
-        | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR
-#endif
-        ,                              // tp_flags
+        | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR, // tp_flags
     (char*)"cppyy template proxy (internal)",     // tp_doc
     (traverseproc)tpp_traverse,        // tp_traverse
     (inquiry)tpp_clear,                // tp_clear
@@ -942,19 +912,11 @@ PyTypeObject TemplateProxy_Type = {
     0,                                 // tp_mro
     0,                                 // tp_cache
     0,                                 // tp_subclasses
-    0                                  // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                                // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                                // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                                // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                                // tp_vectorcall
-#endif
+    0,                                 // tp_weaklist
+    0,                                 // tp_del
+    0,                                 // tp_version_tag
+    0,                                 // tp_finalize
+    0                                  // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/TemplateProxy.h
+++ b/src/TemplateProxy.h
@@ -55,9 +55,7 @@ public:                 // public, as the python C-API works with C structs
     PyObject* fSelf;              // must be first (same layout as CPPOverload)
     PyObject* fTemplateArgs;
     PyObject* fWeakrefList;
-#if PY_VERSION_HEX >= 0x03080000
     vectorcallfunc fVectorCall;
-#endif
     TP_TInfo_t fTI;
 
 public:

--- a/src/TupleOfInstances.cxx
+++ b/src/TupleOfInstances.cxx
@@ -107,19 +107,11 @@ PyTypeObject InstanceArrayIter_Type = {
     (iternextfunc)ia_iternext,    // tp_iternext
     0, 0,
     ia_getset,                    // tp_getset
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                           // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                           // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                           // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,                            // tp_del
+    0,                            // tp_version_tag
+    0,                            // tp_finalize
+    0                             // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 
@@ -242,19 +234,11 @@ PyTypeObject TupleOfInstances_Type = {
     0,                             // tp_mro
     0,                             // tp_cache
     0,                             // tp_subclasses
-    0                              // tp_weaklist
-#if PY_VERSION_HEX >= 0x02030000
-    , 0                            // tp_del
-#endif
-#if PY_VERSION_HEX >= 0x02060000
-    , 0                            // tp_version_tag
-#endif
-#if PY_VERSION_HEX >= 0x03040000
-    , 0                            // tp_finalize
-#endif
-#if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
-#endif
+    0,                             // tp_weaklist
+    0,                             // tp_del
+    0,                             // tp_version_tag
+    0,                             // tp_finalize
+    0                              // tp_vectorcall
     CPYCPPYY_PYTYPE_TAIL
 };
 

--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -114,11 +114,7 @@ namespace {
             gC2POperatorMapping["->"]  = "__follow__";      // not an actual python operator
             gC2POperatorMapping["="]   = "__assign__";      // id.
 
-#if PY_VERSION_HEX < 0x03000000
-            gC2POperatorMapping["bool"] = "__cpp_nonzero__";
-#else
             gC2POperatorMapping["bool"] = "__cpp_bool__";
-#endif
         }
     } initOperatorMapping_;
 
@@ -415,10 +411,6 @@ static bool AddTypeName(std::string& tmpl_name, PyObject* tn, PyObject* arg,
 
     if (tn == (PyObject*)&PyInt_Type) {
         if (arg) {
-#if PY_VERSION_HEX < 0x03000000
-            long l = PyInt_AS_LONG(arg);
-            tmpl_name.append((l < INT_MIN || INT_MAX < l) ? "long" : "int");
-#else
              PY_LONG_LONG ll = PyLong_AsLongLong(arg);
              if (ll == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
                  PyErr_Clear();
@@ -431,33 +423,11 @@ static bool AddTypeName(std::string& tmpl_name, PyObject* tn, PyObject* arg,
              } else
                  tmpl_name.append((ll < INT_MIN || INT_MAX < ll) ? \
                      ((ll < LONG_MIN || LONG_MAX < ll) ? "long long" : "long") : "int");
-#endif
         } else
             tmpl_name.append("int");
 
         return true;
     }
-
-#if PY_VERSION_HEX < 0x03000000
-    if (tn == (PyObject*)&PyLong_Type) {
-        if (arg) {
-             PY_LONG_LONG ll = PyLong_AsLongLong(arg);
-             if (ll == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
-                 PyErr_Clear();
-                 PY_ULONG_LONG ull = PyLong_AsUnsignedLongLong(arg);
-                 if (ull == (PY_ULONG_LONG)-1 && PyErr_Occurred()) {
-                     PyErr_Clear();
-                     tmpl_name.append("long");   // still out of range, will fail later
-                 } else
-                     tmpl_name.append("unsigned long long");    // since already failed long long
-             } else
-                 tmpl_name.append((ll < LONG_MIN || LONG_MAX < ll) ? "long long" : "long");
-        } else
-            tmpl_name.append("long");
-
-        return true;
-    }
-#endif
 
     if (tn == (PyObject*)&PyFloat_Type) {
     // special case for floats (Python-speak for double) if from argument (only)
@@ -465,11 +435,7 @@ static bool AddTypeName(std::string& tmpl_name, PyObject* tn, PyObject* arg,
         return true;
     }
 
-#if PY_VERSION_HEX < 0x03000000
-    if (tn == (PyObject*)&PyString_Type) {
-#else
     if (tn == (PyObject*)&PyUnicode_Type) {
-#endif
         tmpl_name.append("std::string");
         return true;
     }
@@ -691,10 +657,6 @@ static bool AddTypeName(std::vector<Cpp::TemplateArgInfo>& types, PyObject* tn,
 
     if (tn == (PyObject*)&PyInt_Type) {
         if (arg) {
-#if PY_VERSION_HEX < 0x03000000
-            long l = PyInt_AS_LONG(arg);
-            types.push_back(Cppyy::GetType((l < INT_MIN || INT_MAX < l) ? "long" : "int"));
-#else
              PY_LONG_LONG ll = PyLong_AsLongLong(arg);
              if (ll == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
                  PyErr_Clear();
@@ -707,7 +669,6 @@ static bool AddTypeName(std::vector<Cpp::TemplateArgInfo>& types, PyObject* tn,
              } else
                  types.push_back(Cppyy::GetType((ll < INT_MIN || INT_MAX < ll) ? \
                      ((ll < LONG_MIN || LONG_MAX < ll) ? "long long" : "long") : "int").data);
-#endif
         } else {
             types.push_back(Cppyy::GetType("int").data);
         }
@@ -715,38 +676,13 @@ static bool AddTypeName(std::vector<Cpp::TemplateArgInfo>& types, PyObject* tn,
         return true;
     }
 
-#if PY_VERSION_HEX < 0x03000000
-    if (tn == (PyObject*)&PyLong_Type) {
-        if (arg) {
-             PY_LONG_LONG ll = PyLong_AsLongLong(arg);
-             if (ll == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
-                 PyErr_Clear();
-                 PY_ULONG_LONG ull = PyLong_AsUnsignedLongLong(arg);
-                 if (ull == (PY_ULONG_LONG)-1 && PyErr_Occurred()) {
-                     PyErr_Clear();
-                     types.push_back(Cppyy::GetType("long"));   // still out of range, will fail later
-                 } else
-                     types.push_back(Cppyy::GetType("unsigned long long"));    // since already failed long long
-             } else
-                 types.push_back(Cppyy::GetType((ll < LONG_MIN || LONG_MAX < ll) ? "long long" : "long"));
-        } else
-            types.push_back(Cppyy::GetType("long"));
-
-        return true;
-    }
-#endif
-
     if (tn == (PyObject*)&PyFloat_Type) {
     // special case for floats (Python-speak for double) if from argument (only)
         types.push_back(Cppyy::GetType(arg ? "double" : "float").data);
         return true;
     }
 
-#if PY_VERSION_HEX < 0x03000000
-    if (tn == (PyObject*)&PyString_Type) {
-#else
     if (tn == (PyObject*)&PyUnicode_Type) {
-#endif
         types.push_back(Cppyy::GetType("std::string", /* enable_slow_lookup */ true).data);
         return true;
     }
@@ -1142,9 +1078,6 @@ std::unordered_map<std::string, char> const &CPyCppyy::Utility::TypecodeMap()
    static std::unordered_map<std::string, char> typecodeMap{
        {"char",               'b'},
        {"unsigned char",      'B'},
-#if PY_VERSION_HEX < 0x03100000
-       {"wchar_t",            'u'},
-#endif
 #if PY_VERSION_HEX >= 0x030d0000
        {"Py_UCS4",            'w'},
 #endif
@@ -1234,24 +1167,15 @@ Py_ssize_t CPyCppyy::Utility::GetBuffer(PyObject* pyobject, char tc, int size, v
 
     PySequenceMethods* seqmeths = Py_TYPE(pyobject)->tp_as_sequence;
     if (seqmeths != 0 && bufprocs != 0
-#if PY_VERSION_HEX < 0x03000000
-         && bufprocs->bf_getwritebuffer != 0
-         && (*(bufprocs->bf_getsegcount))(pyobject, 0) == 1
-#else
          && bufprocs->bf_getbuffer != 0
-#endif
         ) {
 
    // get the buffer
-#if PY_VERSION_HEX < 0x03000000
-        Py_ssize_t buflen = (*(bufprocs->bf_getwritebuffer))(pyobject, 0, &buf);
-#else
         Py_buffer bufinfo;
         (*(bufprocs->bf_getbuffer))(pyobject, &bufinfo, PyBUF_WRITABLE);
         buf = (char*)bufinfo.buf;
         Py_ssize_t buflen = bufinfo.len;
         PyBuffer_Release(&bufinfo);
-#endif
 
         if (buf && check == true) {
         // determine buffer compatibility (use "buf" as a status flag)
@@ -1416,14 +1340,8 @@ PyObject* CPyCppyy::Utility::PyErr_Occurred_WithGIL()
 // Re-acquire the GIL before calling PyErr_Occurred() in case it has been
 // released; note that the p2.2 code assumes that there are no callbacks in
 // C++ to python (or at least none returning errors).
-#if PY_VERSION_HEX >= 0x02030000
     PythonGILRAII python_gil_raii;
     PyObject* e = PyErr_Occurred();
-#else
-    if (PyThreadState_GET())
-        return PyErr_Occurred();
-    PyObject* e = 0;
-#endif
 
     return e;
 }

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -50,11 +50,7 @@ inline PyObject* CT2CppName(PyObject* pytc, const char* cpd, bool allow_voidp)
     const std::string& name = CT2CppNameS(pytc, allow_voidp);
     if (!name.empty()) {
         if (name == "const char*") cpd = "";
-#if PY_VERSION_HEX < 0x03000000
-        return PyString_FromString((std::string{name}+cpd).c_str());
-#else
         return PyUnicode_FromString((std::string{name}+cpd).c_str());
-#endif
     }
     return nullptr;
 }


### PR DESCRIPTION
About 4 % of the CPyCppyy source code has been carried around to the support of end-of-life Python versions, and removing it will make maintenance easier.