### PR TITLE
Auto-downcast objects returned through smart pointers

### DIFF
--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -189,6 +189,16 @@ Cppyy::TCppScope_t CPyCppyy::CPPInstance::GetSmartIsA() const
 }
 
 //----------------------------------------------------------------------------
+Cppyy::TCppScope_t CPyCppyy::CPPInstance::GetSmartUnderlyingType() const
+{
+// Declared underlying type of the embedded smart pointer ('Base' for a
+// std::unique_ptr<Base>), independent of any downcast of the dereferenced
+// object.
+    if (!IsSmart()) return Cppyy::TCppScope_t{};
+    return SMART_CLS(this)->fUnderlyingType;
+}
+
+//----------------------------------------------------------------------------
 CPyCppyy::CI_DatamemberCache_t& CPyCppyy::CPPInstance::GetDatamemberCache()
 {
 // Return the cache for expensive data objects (and make extended as necessary)

--- a/src/CPPInstance.h
+++ b/src/CPPInstance.h
@@ -77,6 +77,7 @@ public:
     void SetSmart(PyObject* smart_type);
     void* GetSmartObject() { return GetObjectRaw(); }
     Cppyy::TCppScope_t GetSmartIsA() const;
+    Cppyy::TCppScope_t GetSmartUnderlyingType() const;
 
 // cross-inheritance dispatch
     void SetDispatchPtr(void*);

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3061,7 +3061,10 @@ bool CPyCppyy::SmartPtrConverter::SetArg(
     }
 
 // final option, try mapping pointer types held (TODO: do not allow for non-const ref)
-    if (pyobj->IsSmart() && Cppyy::IsSubclass(oisa, fUnderlyingType)) {
+// Match on the declared underlying type, not the (possibly downcast)
+// dereferenced object: a unique_ptr<Base> holding a Derived is still a
+// unique_ptr<Base> and must not pass where a unique_ptr<Derived> is expected.
+    if (pyobj->IsSmart() && Cppyy::IsSubclass(pyobj->GetSmartUnderlyingType(), fUnderlyingType)) {
         para.fValue.fVoidp = ((CPPInstance*)pyobject)->GetSmartObject();
         para.fTypeCode = 'V';
         return true;

--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -843,7 +843,29 @@ PyObject* CPyCppyy::BindCppObjectNoCast(Cppyy::TCppObject_t address,
     PyObject* smart_type = (!(flags & CPPInstance::kNoWrapConv) && \
                             (((CPPClass*)pyclass)->fFlags & CPPScope::kIsSmart)) ? pyclass : nullptr;
     if (smart_type) {
-        pyclass = CreateScopeProxy(((CPPSmartClass*)smart_type)->fUnderlyingType);
+        Cppyy::TCppScope_t underlying = ((CPPSmartClass*)smart_type)->fUnderlyingType;
+
+    // Downcast the underlying object to its actual (most derived) class, as
+    // BindCppObject does for raw pointers, but only when the cast is safe:
+    //  * the actual class must really derive from the declared one;
+    //    GetActualClass() can report a base (e.g. when the actual class has no
+    //    dictionary of its own), and such an up-cast must be rejected.
+    //  * the cast must need no pointer adjustment: the dereferencer always
+    //    returns a pointer to the declared class, so a non-zero offset could
+    //    not be applied consistently on later member access (multiple
+    //    inheritance).
+        if (address && !isRef) {
+            if (void* deref = Cppyy::CallR(
+                ((CPPSmartClass*)smart_type)->fDereferencer, address, 0, nullptr)) {
+                Cppyy::TCppScope_t clActual = Cppyy::GetActualClass(underlying, deref);
+                if (clActual && clActual != underlying &&
+                        Cppyy::IsSubclass(clActual, underlying) &&
+                        Cppyy::GetBaseOffset(clActual, underlying, deref, -1 /* down-cast */) == 0)
+                    underlying = clActual;
+            }
+        }
+
+        pyclass = CreateScopeProxy(underlying);
         if (!pyclass) {
         // simply restore and expose as the actual smart pointer class
             pyclass = smart_type;


### PR DESCRIPTION
Returning an object by raw pointer already triggers an automatic downcast to its actual (most derived) class, but returning it through a smart pointer (`std::unique_ptr`, `std::shared_ptr`) did not: the object was bound as the declared underlying type, so derived-class members were not accessible.

This became more and more of a nuisance as smart pointers become more common in C++ interface.

Therefore, this commit implements automatic downcasting also for returned smart pointers.

Corresponds to:
https://github.com/root-project/root/commit/6f366acb6b638de9b0a3560ee6e28f04536c540f