### PR TITLE
Avoid compiler warnings with Python 3.15

### DIFF
--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -311,12 +311,7 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/CPPExcInstance.cxx
+++ b/src/CPPExcInstance.cxx
@@ -285,12 +285,7 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                            // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                            // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -1125,12 +1125,7 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -1109,12 +1109,7 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                                // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                                // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -706,12 +706,7 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/CPyCppyy.h
+++ b/src/CPyCppyy.h
@@ -385,4 +385,34 @@ static inline PyObject* PyObject_CallMethodOneArg(PyObject* obj, PyObject* name,
 // export macros for our own API
 #include "CPyCppyy/CommonDefs.h"
 
+// --- reusable PyTypeObject initializer tail -------------------------------
+// Members appended to PyTypeObject in newer CPython releases. Every CPyCppyy
+// type leaves all of these zero/null-initialized, so they share one tail.
+// To support a future Python version, add one block below and one line to
+// CPYCPPYY_PYTYPE_TAIL.
+
+#if PY_VERSION_HEX >= 0x030c0000
+#define CPYCPPYY_TP_WATCHED        , 0          /* tp_watched      (>= 3.12) */
+#else
+#define CPYCPPYY_TP_WATCHED
+#endif
+
+#if PY_VERSION_HEX >= 0x030d0000
+#define CPYCPPYY_TP_VERSIONS_USED  , 0          /* tp_versions_used(>= 3.13) */
+#else
+#define CPYCPPYY_TP_VERSIONS_USED
+#endif
+
+#if PY_VERSION_HEX >= 0x030f0000
+#define CPYCPPYY_TP_ITERITEM       , nullptr    /* _tp_iteritem    (>= 3.15) */
+#else
+#define CPYCPPYY_TP_ITERITEM
+#endif
+
+#define CPYCPPYY_PYTYPE_TAIL \
+    CPYCPPYY_TP_WATCHED \
+    CPYCPPYY_TP_VERSIONS_USED \
+    CPYCPPYY_TP_ITERITEM
+// --------------------------------------------------------------------------
+
 #endif // !CPYCPPYY_CPYCPPYY_H

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -175,12 +175,7 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                  // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                  // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                  // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -222,12 +217,7 @@ static PyTypeObject PyDefault_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                 // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                 // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                 // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 namespace {

--- a/src/CustomPyTypes.cxx
+++ b/src/CustomPyTypes.cxx
@@ -167,12 +167,7 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -341,12 +336,7 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -401,12 +391,7 @@ PyTypeObject IndexIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -472,12 +457,7 @@ PyTypeObject VectorIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/LowLevelViews.cxx
+++ b/src/LowLevelViews.cxx
@@ -980,12 +980,7 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                            // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                            // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -955,12 +955,7 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                                // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                                // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/src/TupleOfInstances.cxx
+++ b/src/TupleOfInstances.cxx
@@ -120,12 +120,7 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -260,12 +255,7 @@ PyTypeObject TupleOfInstances_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy


### PR DESCRIPTION
This avoids compiler warnings about missing field initializers because of a new data member in Python 3.15.

Also, refactor the code a bit, so that next time a new member is added, we just have to change the code in one place.

Corresponding ROOT commit:
https://github.com/root-project/root/commit/917096a874ff1e73fc5bcd357cc83d4a3b3893f3