### PR TITLE
Fix `-Winconsistent-missing-override` warnings

### DIFF
--- a/src/Converters.h
+++ b/src/Converters.h
@@ -53,7 +53,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[VoidArrayConverter] " + fFailureMsg; }
+    std::string GetFailureMsg() override { return "[VoidArrayConverter] " + fFailureMsg; }
 
 protected:
     virtual bool GetAddressSpecialCase(PyObject* pyobject, void*& address);

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -21,14 +21,14 @@ public:                                                                      \
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;      \
     PyObject* FromMemory(void*) override;                                     \
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;            \
-    virtual std::string GetFailureMsg() { return "[" #name "Converter]"; }   \
+    std::string GetFailureMsg() override { return "[" #name "Converter]"; }   \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
 public:                                                                      \
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;      \
     PyObject* FromMemory(void*) override;                                     \
-    virtual std::string GetFailureMsg() { return "[Const" #name "RefConverter]"; }\
+    std::string GetFailureMsg() override { return "[Const" #name "RefConverter]"; }\
 }
 
 
@@ -37,14 +37,14 @@ class name##Converter : public base##Converter {                             \
 public:                                                                      \
     PyObject* FromMemory(void*) override;                                     \
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;            \
-    virtual std::string GetFailureMsg() { return "[" #name "Converter]"; }   \
+    std::string GetFailureMsg() override { return "[" #name "Converter]"; }   \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
 public:                                                                      \
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;      \
     PyObject* FromMemory(void*) override;                                     \
-    virtual std::string GetFailureMsg() { return "[Const" #name "RefConverter]"; }\
+    std::string GetFailureMsg() override { return "[Const" #name "RefConverter]"; }\
 }
 
 #define CPPYY_DECLARE_REFCONVERTER(name)                                     \
@@ -52,7 +52,7 @@ class name##RefConverter : public Converter {                                \
 public:                                                                      \
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;      \
     PyObject* FromMemory(void*) override;                                     \
-    virtual std::string GetFailureMsg() { return "[" #name "RefConverter]"; }\
+    std::string GetFailureMsg() override { return "[" #name "RefConverter]"; }\
 };
 
 #define CPPYY_DECLARE_ARRAY_CONVERTER(name)                                  \
@@ -64,8 +64,8 @@ public:                                                                      \
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;      \
     PyObject* FromMemory(void*) override;                                     \
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;            \
-    bool HasState() { return true; }                                 \
-    virtual std::string GetFailureMsg() { return "[" #name "ArrayConverter]"; }\
+    bool HasState() override { return true; }                                 \
+    std::string GetFailureMsg() override { return "[" #name "ArrayConverter]"; }\
 protected:                                                                   \
     dims_t fShape;                                                           \
     bool fIsFixed;                                                           \
@@ -138,7 +138,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[CStringConverter]"; }
+    std::string GetFailureMsg() override { return "[CStringConverter]"; }
 
 protected:
     std::string fBuffer;
@@ -152,7 +152,7 @@ public:
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
-    virtual std::string GetFailureMsg() { return "[NonConstCStringConverter]"; }
+    std::string GetFailureMsg() override { return "[NonConstCStringConverter]"; }
 };
 
 class WCStringConverter : public Converter {
@@ -168,7 +168,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[WCStringConverter]"; };
+    std::string GetFailureMsg() override { return "[WCStringConverter]"; };
 
 protected:
     wchar_t* fBuffer;
@@ -188,7 +188,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[CString16Converter]"; };
+    std::string GetFailureMsg() override { return "[CString16Converter]"; };
 
 protected:
     char16_t* fBuffer;
@@ -208,7 +208,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[CString32Converter]"; };
+    std::string GetFailureMsg() override { return "[CString32Converter]"; };
 
 protected:
     char32_t* fBuffer;
@@ -244,7 +244,7 @@ public:
     using SCharArrayConverter::SCharArrayConverter;
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
-    virtual std::string GetFailureMsg() { return "[CStringArrayConverter]"; };
+    std::string GetFailureMsg() override { return "[CStringArrayConverter]"; };
 
 private:
     std::vector<const char*> fBuffer;
@@ -254,7 +254,7 @@ class NonConstCStringArrayConverter : public CStringArrayConverter {
 public:
     using CStringArrayConverter::CStringArrayConverter;
     PyObject* FromMemory(void* address) override;
-    virtual std::string GetFailureMsg() { return "[NonConstCStringArrayConverter]"; };
+    std::string GetFailureMsg() override { return "[NonConstCStringArrayConverter]"; };
 };
 
 // converters for special cases
@@ -269,7 +269,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void*) override;
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[InstanceConverter]"; };
+    std::string GetFailureMsg() override { return "[InstanceConverter]"; };
 };
 
 class InstanceRefConverter : public Converter  {
@@ -281,7 +281,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[InstanceRefConverter]"; };
+    std::string GetFailureMsg() override { return "[InstanceRefConverter]"; };
 
 protected:
     Cppyy::TCppScope_t fClass;
@@ -292,7 +292,7 @@ class InstanceMoveConverter : public InstanceRefConverter  {
 public:
     InstanceMoveConverter(Cppyy::TCppScope_t klass) : InstanceRefConverter(klass, true) {}
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[InstanceMoveConverter]"; };
+    std::string GetFailureMsg() override { return "[InstanceMoveConverter]"; };
 };
 
 template <bool ISREFERENCE>
@@ -304,7 +304,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[InstancePtrPtrConverter]"; };
+    std::string GetFailureMsg() override { return "[InstancePtrPtrConverter]"; };
 };
 
 class InstanceArrayConverter : public InstancePtrConverter<false> {
@@ -318,7 +318,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[InstanceArrayConverter]"; };
+    std::string GetFailureMsg() override { return "[InstanceArrayConverter]"; };
 
 protected:
     dims_t fShape;
@@ -334,7 +334,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[ComplexDConverter]"; };
+    std::string GetFailureMsg() override { return "[ComplexDConverter]"; };
 
 private:
     std::complex<double> fBuffer;
@@ -346,7 +346,7 @@ private:
 class STLIteratorConverter : public Converter {
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[STLIteratorConverter]"; };
+    std::string GetFailureMsg() override { return "[STLIteratorConverter]"; };
 };
 // -- END Cling WORKAROUND
 
@@ -354,7 +354,7 @@ public:
 class VoidPtrRefConverter : public Converter {
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[VoidPtrRefConverter]"; };
+    std::string GetFailureMsg() override { return "[VoidPtrRefConverter]"; };
 };
 
 class VoidPtrPtrConverter : public Converter {
@@ -363,7 +363,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[VoidPtrPtrConverter] " + fFailureMsg; }
+    std::string GetFailureMsg() override { return "[VoidPtrPtrConverter] " + fFailureMsg; }
 
 protected:
     dims_t fShape;
@@ -384,7 +384,7 @@ public:                                                                      \
     PyObject* FromMemory(void* address) override;                             \
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;            \
     bool HasState() override { return true; }                                 \
-    virtual std::string GetFailureMsg() { return "[" #name "Converter]"; };  \
+    std::string GetFailureMsg() override { return "[" #name "Converter]"; };  \
 protected:                                                                   \
     strtype fBuffer;                                                         \
 }
@@ -399,7 +399,7 @@ public:
 
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[STLStringMoveConverter]"; };
+    std::string GetFailureMsg() override { return "[STLStringMoveConverter]"; };
 };
 
 
@@ -414,7 +414,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[FunctionPointerConverter]"; };
+    std::string GetFailureMsg() override { return "[FunctionPointerConverter]"; };
 
 protected:
     std::string fRetType;
@@ -437,7 +437,7 @@ public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
-    virtual std::string GetFailureMsg() { return "[StdFunctionConverter]"; };
+    std::string GetFailureMsg() override { return "[StdFunctionConverter]"; };
 
 protected:
     Converter* fConverter;
@@ -459,7 +459,7 @@ public:
     PyObject* FromMemory(void* address) override;
     bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[SmartPtrConverter]"; };
+    std::string GetFailureMsg() override { return "[SmartPtrConverter]"; };
 
 protected:
     virtual bool GetAddressSpecialCase(PyObject*, void*&) { return false; }
@@ -482,7 +482,7 @@ public:
 public:
     bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
     bool HasState() override { return true; }
-    virtual std::string GetFailureMsg() { return "[FunctionPointerConverter]"; };
+    std::string GetFailureMsg() override { return "[FunctionPointerConverter]"; };
 
 protected:
     void Clear();


### PR DESCRIPTION
These warnings need to be fixed, because the ROOT CI doesn't tolerate them.