### PR TITLE
Fix this-pointer offset for using-declared base methods

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -1067,10 +1067,18 @@ PyObject* CPyCppyy::CPPMethod::Call(CPPInstance*& self,
 // get its class
     Cppyy::TCppScope_t derived = self->ObjectIsA();
 
-// calculate offset (the method expects 'this' to be an object of fScope)
+// calculate offset: the generated wrapper casts 'this' to the method's actual
+// declaring class, which may differ from fScope. In particular, a method
+// brought into fScope through a using-declaration (e.g. `using Base::meth;`)
+// is still declared in the base, so 'this' has to be adjusted to that base's
+// subobject. Using fScope here would yield a zero offset and corrupt memory.
+    Cppyy::TCppScope_t declaring = Cppyy::GetParentScope(Cppyy::TCppScope_t(fMethod.data));
+    if (!declaring)
+        declaring = fScope;
+
     ptrdiff_t offset = 0;
-    if (derived && derived != fScope)
-        offset = Cppyy::GetBaseOffset(derived, fScope, object, 1 /* up-cast */);
+    if (derived && derived != declaring)
+        offset = Cppyy::GetBaseOffset(derived, declaring, object, 1 /* up-cast */);
 
 // actual call; recycle self instead of returning new object for same address objects
     CPPInstance* pyobj = (CPPInstance*)Execute(object, offset, ctxt);


### PR DESCRIPTION
When a derived class pulls a base method into its own overload set with `using Base::method;`, the method is still declared in the base. If that base is not the first one, its subobject sits at a non-zero offset in the derived object.

`CPPMethod::Call` computed the this-pointer offset against `fScope` (the class the method is bound on, i.e. the derived class) rather than the method's declaring base. For a using-declared method these differ, yielding a zero offset. The generated wrapper, however, casts 'this' to the declaring base, so the call wrote through an unadjusted pointer, corrupting memory and crashing on destruction.

Compute the offset against the method's declaring scope (`Cppyy::GetParentScope`) instead. This is a no-op for ordinary inherited methods, which are bound on their declaring base already.

Surfaced by `roottest-python-cpp-cpp` (`TGraphMultiErrors::SetLineColor`, where `TAttLine` is a secondary base).