### PR TITLE
Skip smart pointer check for namespaces

### DIFF
--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -203,8 +203,14 @@ static PyObject* pt_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
     subtype->tp_dealloc = (destructor)meta_dealloc;
 
 // creation of the python-side class; extend the size if this is a smart ptr
-    Cppyy::TCppScope_t raw; Cppyy::TCppMethod_t deref;
-    if (CPPScope_CheckExact(subtype)) {
+//
+// A namespace can never be a smart pointer, so skip the check for namespaces.
+// This matters beyond performance: GetSmartPtrInfo() resolves the scope name
+// through a slow interpreter lookup that triggers autoloading of the library
+// providing the scope, which we don't want to do unnecessarily.
+    Cppyy::TCppScope_t raw;
+    Cppyy::TCppMethod_t deref;
+    if (CPPScope_CheckExact(subtype) && !Cppyy::IsNamespace(((CPPScope*)subtype)->fCppType)) {
         if (Cppyy::GetSmartPtrInfo(Cppyy::GetScopedFinalName(((CPPScope*)subtype)->fCppType), &raw, &deref))
             subtype->tp_basicsize = sizeof(CPPSmartClass);
     }


### PR DESCRIPTION
A namespace can never be a smart pointer, so skip the check for namespaces. This matters beyond performance: GetSmartPtrInfo() resolves the scope name through a slow interpreter lookup that triggers autoloading of the library providing the scope, which we don't want to do unnecessarily.

For a namespace that is only used as a Python-side container (e.g. `TMVA::Experimental::SOFIE::PyKeras`, whose attributes are injected by pythonizations) this would needlessly `dlopen` that library and drag all of its dependencies into the global symbol namespace, resulting in protobuf symbol collisions.