### PR TITLE
Return empty string instead of nullptr for unknown typecode

### DIFF
--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -884,7 +884,7 @@ std::string CPyCppyy::Utility::CT2CppNameS(PyObject* pytc, bool allow_voidp)
             case 'd': name = "double";             break;
             case 'g': name = "long double";        break;
             case 'z': name = "const char*";        break;
-            default:  name = (allow_voidp ? "void*" : nullptr); break;
+            default:  if (allow_voidp) name = "void*"; break;
         }
     }
 


### PR DESCRIPTION
Otherwise this block treats an empty result as "no match" and returns `nullptr` to its caller. When `void*` was not allowed, the default branch of CT2CppNameS instead assigned a null const char* to the std::string result, constructing a std::string from a null pointer (undefined and throws `std::logic_error`). 

This surfaces through `cppyy.ll.array_delete` on multi-level pointers such as `char**`, where the element type falls through to the default branch. Test: https://github.com/compiler-research/cppyy/pull/233