### PR TITLE
Make bool-based enum values real instances of their enum class

### DIFF
--- a/src/CPPEnum.cxx
+++ b/src/CPPEnum.cxx
@@ -24,10 +24,11 @@ PyObject* CPyCppyy::pyval_from_enum(const std::string& enum_type, PyObject* pyty
         PyObject* btype, Cppyy::TCppScope_t enum_constant) {
     long long llval = Cppyy::GetEnumDataValue(enum_constant);
 
-    if (enum_type == "bool") {
+    if (enum_type == "bool" && !(pytype && btype)) {
+    // no enum class to instantiate; the singletons can not carry attributes
         PyObject* result = (bool)llval ? Py_True : Py_False;
         Py_INCREF(result);
-        return result;                      // <- immediate return;
+        return result;
     }
 
     PyObject* bval;
@@ -210,12 +211,9 @@ CPyCppyy::CPPEnum* CPyCppyy::CPPEnum_New(const std::string& name, Cppyy::TCppSco
             PyObject* pydname = CPyCppyy_PyText_FromString(dname.c_str());
             PyObject_SetAttr(pyenum, pydname, val);
             Py_DECREF(pydname);
-            if (resolved != "bool") {
-                // bool is special cased enum look at pyval_from_enum
-                PyObject* pydcppname = CPyCppyy_PyText_FromString((ename.empty() ? dname : (ename+"::"+dname)).c_str());
-                PyObject_SetAttr(val, PyStrings::gCppName, pydcppname);
-                Py_DECREF(pydcppname);
-            }
+            PyObject* pydcppname = CPyCppyy_PyText_FromString((ename.empty() ? dname : (ename+"::"+dname)).c_str());
+            PyObject_SetAttr(val, PyStrings::gCppName, pydcppname);
+            Py_DECREF(pydcppname);
             Py_DECREF(val);
         }
 


### PR DESCRIPTION
Partial fix for compiler-research/cppyy#198 (the `enum class : bool` half).

- `pyval_from_enum` returned the `Py_True`/`Py_False` singletons for enums with a bool underlying type, so enumerators were never instances of the enum's Python class — breaking e.g. `enum.Enum` construction from the class `__dict__` — and could not carry `__cpp_name__`.
- Now constructs proper instances (int-based, since CPython's `bool` cannot be subclassed) like every other underlying type; the singleton shortcut remains only for the null-`pytype` data-member path.
- Note this is a behavior change: `type(E.val)` was `bool`, now it is the enum class (still `isinstance(..., int)`, still compares equal to `True`/`False`). The companion cppyy PR updates the `test11_typed_enums` assertions accordingly and un-xfails `test51_enum_integrity`.

Full cppyy suite is clean with this change (510 passed, 0 failures).

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)