### PR TITLE
Improve error reporting for method calls without C++ object available

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -1021,7 +1021,8 @@ PyObject* CPyCppyy::CPPMethod::Call(CPPInstance*& self,
 
 // validity check that should not fail
     if (!object) {
-        PyErr_SetString(PyExc_ReferenceError, "attempt to access a null-pointer");
+        PyErr_SetString(PyExc_ReferenceError, "no C++ object available");
+        ctxt->fFlags |= CallContext::kCppException;
         return nullptr;
     }
 

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -622,7 +622,7 @@ static PyObject* mp_vectorcall(
             return HandleReturn(pymeth, im_self, result);
 
     // fall through: python is dynamic, and so, the hashing isn't infallible
-        ctxt.fFlags &= ~CallContext::kAllowImplicit;
+        ctxt.fFlags &= ~(CallContext::kAllowImplicit | CallContext::kPyException | CallContext::kCppException);
         PyErr_Clear();
         ResetCallState(pymeth->fSelf, im_self);
     }


### PR DESCRIPTION
Currently, all overloads are tried and error for each call is reported as part of TypeError. With the change, only the the fact that "no C++ object available" is reported as ReferenceError which is the real error cause.

src/CPPMethod.cxx: signal the unavailability of C++ object as CallContext::kCppException (used by Utility::SetDetailedException)
src/CPPOverload.cxx: clear CallContext::kCppException before trying further calls