### PR TITLE
Fix type confusion in MakeCppTemplateClass's instantiation-failure error path

### DIFF
--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -385,7 +385,7 @@ static PyObject* MakeCppTemplateClass(PyObject* /* self */, PyObject* args)
     if (!scope) {
       PyErr_Format(PyExc_TypeError,
                    "Template instantiation failed: '%s' with args: '%s\n'",
-                   Cppyy::GetScopedFinalName(cppscope).c_str(),
+                   Cppyy::GetScopedFinalName(tmpl).c_str(),
                    CPyCppyy_PyText_AsString(PyObject_Repr(args)));
       return nullptr;
     }


### PR DESCRIPTION
`MakeCppTemplateClass`'s failure branch formats its error message with `Cppyy::GetScopedFinalName(cppscope)` — the raw `PyObject*` tuple element, not the unwrapped template pointer assigned two lines above. `TCppScope_t` is `void*`, so it converts silently and `GetScopedFinalName` reinterprets the PyObject's memory as a clang `Decl`: junk text (`'<unnamed>'`) when the garbage read survives, a segfault when it faults — UB on every instantiation rejected after its arguments resolved. Deterministic repro:

```python
cppyy.cppdef("namespace p { template <unsigned N> struct Buf { int tag; }; }")
cppyy.gbl.p.Buf["int"]   # type arg for non-type param → instantiation fails
# TypeError: Template instantiation failed: '<unnamed>' ...   (should be 'p::Buf')
```

One-token fix: pass `tmpl`. Regression test in compiler-research/cppyy#236 (CPyCppyy carries no test suite of its own).

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)
